### PR TITLE
Source-view toggle: review the new code without diff noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Optional `config.toml` in the plugin's config dir (find it with `herdr plugin co
 | File list | `j`/`k` move · `g`/`G` ends · `l`/`Enter`/`Tab` → diff | wheel moves selection, click opens a file |
 | Diff | `j`/`k` cursor · `←`/`→` (or `H`/`L`) pan wide lines, `0` resets · `d`/`u` half page · `n`/`p` hunks · `g`/`G` ends · `h`/`Tab` → files | wheel scrolls, horizontal wheel pans, click places the cursor, drag selects a range |
 | Annotate | `v` select range · `c` comment (Ctrl-T cycles tag, `Enter` saves, `Esc` backs out) · `c` on an annotated line edits · `x` deletes | drag then `c` |
-| Layout | `b` hide/show the file list · `z` zoom the pane full-screen | — |
+| Layout | `b` hide/show the file list · `z` zoom the pane full-screen · `t` diff/source view | — |
 | Finish | `a` approve · `r` request changes + summary · `q` cancel | — |
 
 Long lines clip with `‹`/`…` markers; pan to see the rest. Annotations ride

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,6 +5,7 @@
 //! lines 112–118 of src/portal.rs") can be derived directly from the cursor
 //! position without re-parsing anything.
 
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -152,6 +153,20 @@ pub fn load(working_dir: &str, baseline: Option<&str>) -> Result<DiffModel> {
     }
 
     Ok(DiffModel { files })
+}
+
+/// Read a file's post-change contents as lines, for the UI's source view.
+///
+/// No git plumbing needed regardless of baseline: the worktree IS the new
+/// side of the diff, so the file on disk is exactly what the annotations'
+/// `Side::New` line numbers refer to. Binary files (`read_to_string` rejects
+/// non-UTF-8), deleted files, and unreadable ones come back as `Err`; the UI
+/// turns that into a placeholder row rather than failing the review.
+pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
+    let full = Path::new(working_dir).join(path);
+    let text = std::fs::read_to_string(&full)
+        .with_context(|| format!("reading {}", full.display()))?;
+    Ok(text.lines().map(|line| line.to_string()).collect())
 }
 
 /// Parse `git diff --no-color` unified output into file diffs.

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -162,8 +162,21 @@ pub fn load(working_dir: &str, baseline: Option<&str>) -> Result<DiffModel> {
 /// `Side::New` line numbers refer to. Binary files (`read_to_string` rejects
 /// non-UTF-8), deleted files, and unreadable ones come back as `Err`; the UI
 /// turns that into a placeholder row rather than failing the review.
+///
+/// Symlinks are refused rather than followed: git's diff for a symlink shows
+/// the link's target STRING as the file's one-line content, but
+/// `read_to_string` would dereference the link and render whatever it points
+/// at instead — including files well outside the repo (`/etc/passwd`, an SSH
+/// key) if a reviewed change plants a symlink pointing there. Checking
+/// `symlink_metadata` (which does not follow the link) before ever opening
+/// the target keeps that content out of the pane.
 pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
     let full = Path::new(working_dir).join(path);
+    let meta = std::fs::symlink_metadata(&full)
+        .with_context(|| format!("reading {}", full.display()))?;
+    if meta.file_type().is_symlink() {
+        bail!("{} is a symlink; source view does not follow worktree symlinks", full.display());
+    }
     let text = std::fs::read_to_string(&full)
         .with_context(|| format!("reading {}", full.display()))?;
     Ok(text.lines().map(|line| line.to_string()).collect())
@@ -864,5 +877,32 @@ index 1111111..2222222 100644
                 assert_eq!(line.origin, Origin::Add);
             }
         }
+    }
+
+    #[test]
+    fn load_source_refuses_a_symlink_instead_of_following_it_outside_the_repo() {
+        // Regression (Codex P0): read_to_string follows symlinks. A reviewed
+        // change that plants a symlink pointing outside the repo — a secret
+        // file, an SSH key — must not have its target's content rendered in
+        // source view just because the reviewer pressed `t`.
+        let repo = TempRepo::new("symlink_source");
+
+        let secret_dir = std::env::temp_dir()
+            .join(format!("herdr_diff_test_secret_{}", std::process::id()));
+        std::fs::create_dir_all(&secret_dir).expect("create secret dir");
+        let secret_path = secret_dir.join("secret.txt");
+        std::fs::write(&secret_path, "TOP SECRET, outside the repo\n").expect("write secret");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&secret_path, repo.path.join("link.txt"))
+            .expect("create symlink");
+
+        let wd = repo.path.to_str().expect("utf8 path").to_string();
+        let result = load_source(&wd, "link.txt");
+        assert!(result.is_err(), "a symlink must be refused, not dereferenced: {result:?}");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("symlink"), "error should name the reason, got {msg:?}");
+
+        let _ = std::fs::remove_dir_all(&secret_dir);
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -155,6 +155,15 @@ pub fn load(working_dir: &str, baseline: Option<&str>) -> Result<DiffModel> {
     Ok(DiffModel { files })
 }
 
+/// Source view refuses to load a file larger than this: reading, copying
+/// every line, and syntax-highlighting the whole thing runs synchronously on
+/// the render thread (this is a single-threaded TUI event loop, not an async
+/// one), so an unbounded read of a large generated or minified file — cheap
+/// to review as a small DIFF — would freeze the pane for however long that
+/// takes. 2 MiB comfortably covers real source files while still catching
+/// the generated/minified/vendored case the diff itself never has to pay for.
+const MAX_SOURCE_BYTES: u64 = 2 * 1024 * 1024;
+
 /// Read a file's post-change contents as lines, for the UI's source view.
 ///
 /// No git plumbing needed regardless of baseline: the worktree IS the new
@@ -170,12 +179,25 @@ pub fn load(working_dir: &str, baseline: Option<&str>) -> Result<DiffModel> {
 /// key) if a reviewed change plants a symlink pointing there. Checking
 /// `symlink_metadata` (which does not follow the link) before ever opening
 /// the target keeps that content out of the pane.
+///
+/// Files over `MAX_SOURCE_BYTES` are refused for the same reason binary
+/// files are: there is nothing useful — or safe to the pane's
+/// responsiveness — to render, so the UI shows a placeholder instead of
+/// blocking on the read and the highlight pass that follows it.
 pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
     let full = Path::new(working_dir).join(path);
     let meta = std::fs::symlink_metadata(&full)
         .with_context(|| format!("reading {}", full.display()))?;
     if meta.file_type().is_symlink() {
         bail!("{} is a symlink; source view does not follow worktree symlinks", full.display());
+    }
+    if meta.len() > MAX_SOURCE_BYTES {
+        bail!(
+            "{} is {} bytes, over the {}-byte source view limit",
+            full.display(),
+            meta.len(),
+            MAX_SOURCE_BYTES
+        );
     }
     let text = std::fs::read_to_string(&full)
         .with_context(|| format!("reading {}", full.display()))?;
@@ -904,5 +926,28 @@ index 1111111..2222222 100644
         assert!(msg.contains("symlink"), "error should name the reason, got {msg:?}");
 
         let _ = std::fs::remove_dir_all(&secret_dir);
+    }
+
+    #[test]
+    fn load_source_refuses_a_file_over_the_size_limit() {
+        // Regression (Codex P1): source view read, copied, and
+        // syntax-highlighted a file of any size synchronously on the render
+        // thread. A generated/minified file the diff itself never had to pay
+        // for could freeze the pane just because the reviewer pressed `t`.
+        let repo = TempRepo::new("oversized_source");
+        let oversized = "x".repeat((MAX_SOURCE_BYTES + 1) as usize);
+        repo.write("huge.txt", &oversized);
+
+        let wd = repo.path.to_str().expect("utf8 path").to_string();
+        let result = load_source(&wd, "huge.txt");
+        assert!(result.is_err(), "an oversized file must be refused: {result:?}");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("limit"), "error should name the reason, got {msg:?}");
+
+        // A file right at the limit still loads normally — this guards the
+        // limit itself, not files that merely happen to be sizeable.
+        let at_limit = "y".repeat(MAX_SOURCE_BYTES as usize);
+        repo.write("at_limit.txt", &at_limit);
+        assert!(load_source(&wd, "at_limit.txt").is_ok(), "a file at the limit must still load");
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -164,6 +164,18 @@ pub fn load(working_dir: &str, baseline: Option<&str>) -> Result<DiffModel> {
 /// the generated/minified/vendored case the diff itself never has to pay for.
 const MAX_SOURCE_BYTES: u64 = 2 * 1024 * 1024;
 
+/// Source view also refuses a file with more rows than this, independent of
+/// the byte cap above: a file well under 2 MiB can still hold tens of
+/// thousands of very short lines. The ratatui `Paragraph::scroll` the pane
+/// renders through takes a `u16` row offset, so a source view with more than
+/// `u16::MAX` rows could need a scroll position that silently wraps when
+/// narrowed to `u16` — the pane would then render unrelated earlier rows
+/// while the cursor and footer, which track the real `usize` position,
+/// still report the true (later) line. 50,000 leaves a wide margin under
+/// `u16::MAX` (65,535) for the extra display rows woven-in annotation
+/// comments add on top of the base row count.
+const MAX_SOURCE_LINES: usize = 50_000;
+
 /// Read a file's post-change contents as lines, for the UI's source view.
 ///
 /// No git plumbing needed regardless of baseline: the worktree IS the new
@@ -183,7 +195,8 @@ const MAX_SOURCE_BYTES: u64 = 2 * 1024 * 1024;
 /// Files over `MAX_SOURCE_BYTES` are refused for the same reason binary
 /// files are: there is nothing useful — or safe to the pane's
 /// responsiveness — to render, so the UI shows a placeholder instead of
-/// blocking on the read and the highlight pass that follows it.
+/// blocking on the read and the highlight pass that follows it. Files over
+/// `MAX_SOURCE_LINES` are refused for the separate reason documented there.
 pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
     let full = Path::new(working_dir).join(path);
     let meta = std::fs::symlink_metadata(&full)
@@ -201,7 +214,16 @@ pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
     }
     let text = std::fs::read_to_string(&full)
         .with_context(|| format!("reading {}", full.display()))?;
-    Ok(text.lines().map(|line| line.to_string()).collect())
+    let lines: Vec<String> = text.lines().map(|line| line.to_string()).collect();
+    if lines.len() > MAX_SOURCE_LINES {
+        bail!(
+            "{} has {} lines, over the {}-line source view limit",
+            full.display(),
+            lines.len(),
+            MAX_SOURCE_LINES
+        );
+    }
+    Ok(lines)
 }
 
 /// Parse `git diff --no-color` unified output into file diffs.
@@ -949,5 +971,39 @@ index 1111111..2222222 100644
         let at_limit = "y".repeat(MAX_SOURCE_BYTES as usize);
         repo.write("at_limit.txt", &at_limit);
         assert!(load_source(&wd, "at_limit.txt").is_ok(), "a file at the limit must still load");
+    }
+
+    #[test]
+    fn load_source_refuses_a_file_with_too_many_lines() {
+        // Regression (Codex P1): ratatui's `Paragraph::scroll` takes a `u16`
+        // row offset. A file well under the byte cap can still hold tens of
+        // thousands of very short lines; scrolling into one would need an
+        // offset that silently wraps when narrowed from `usize` to `u16`,
+        // rendering unrelated earlier rows while the cursor/footer still
+        // report the true (later, wrapped-away) line. Bytes alone don't
+        // catch this, so the line count needs its own, separate cap.
+        let repo = TempRepo::new("too_many_lines");
+        // Short lines so this is nowhere near MAX_SOURCE_BYTES — this test
+        // isolates the LINE cap, not the byte one.
+        let many_lines = "x\n".repeat(MAX_SOURCE_LINES + 1);
+        assert!(
+            (many_lines.len() as u64) < MAX_SOURCE_BYTES,
+            "test setup must stay under the byte cap to isolate the line cap"
+        );
+        repo.write("many_lines.txt", &many_lines);
+
+        let wd = repo.path.to_str().expect("utf8 path").to_string();
+        let result = load_source(&wd, "many_lines.txt");
+        assert!(result.is_err(), "a file with too many lines must be refused: {result:?}");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("lines"), "error should name the reason, got {msg:?}");
+
+        // A file at exactly the limit still loads.
+        let at_limit = "x\n".repeat(MAX_SOURCE_LINES);
+        repo.write("at_limit_lines.txt", &at_limit);
+        assert!(
+            load_source(&wd, "at_limit_lines.txt").is_ok(),
+            "a file at the line limit must still load"
+        );
     }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,6 +5,7 @@
 //! lines 112–118 of src/portal.rs") can be derived directly from the cursor
 //! position without re-parsing anything.
 
+use std::io::Read as _;
 use std::path::Path;
 use std::process::Command;
 
@@ -197,24 +198,64 @@ const MAX_SOURCE_LINES: usize = 50_000;
 /// responsiveness — to render, so the UI shows a placeholder instead of
 /// blocking on the read and the highlight pass that follows it. Files over
 /// `MAX_SOURCE_LINES` are refused for the separate reason documented there.
+///
+/// The symlink and size checks above run against the PATH
+/// (`symlink_metadata`), then the actual read opens that same path again —
+/// two separate filesystem operations with a gap between them. Something
+/// with write access to the reviewed worktree (the review pane's own
+/// threat model: a reviewed CHANGE, not a trusted actor) could swap the
+/// path for a symlink, or grow the file past the cap, in that gap, and
+/// have the read follow whatever it now finds. Closing that requires
+/// re-validating the OPENED FILE, not the path a second time: after
+/// opening, `same_file` compares the handle's own device/inode against
+/// what the pre-open check inspected — this is the one thing a
+/// racing path-swap cannot fake, since a symlink swap produces a
+/// different underlying file — and the read itself is hard-capped via
+/// `Read::take` regardless of what any stat reported.
 pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
     let full = Path::new(working_dir).join(path);
-    let meta = std::fs::symlink_metadata(&full)
+    let pre = std::fs::symlink_metadata(&full)
         .with_context(|| format!("reading {}", full.display()))?;
-    if meta.file_type().is_symlink() {
+    if pre.file_type().is_symlink() {
         bail!("{} is a symlink; source view does not follow worktree symlinks", full.display());
     }
-    if meta.len() > MAX_SOURCE_BYTES {
+    if pre.len() > MAX_SOURCE_BYTES {
         bail!(
             "{} is {} bytes, over the {}-byte source view limit",
             full.display(),
-            meta.len(),
+            pre.len(),
             MAX_SOURCE_BYTES
         );
     }
-    let text = std::fs::read_to_string(&full)
+
+    let file = std::fs::File::open(&full)
         .with_context(|| format!("reading {}", full.display()))?;
-    let lines: Vec<String> = text.lines().map(|line| line.to_string()).collect();
+    let post = file.metadata().with_context(|| format!("reading {}", full.display()))?;
+    #[cfg(unix)]
+    if !same_file(&pre, &post) {
+        bail!("{} changed while opening it; refusing a racy read", full.display());
+    }
+    if post.len() > MAX_SOURCE_BYTES {
+        bail!(
+            "{} is {} bytes, over the {}-byte source view limit",
+            full.display(),
+            post.len(),
+            MAX_SOURCE_BYTES
+        );
+    }
+
+    // However large `post.len()` claims to be, never actually read more
+    // than the cap allows — a size that changes again after this last
+    // stat is caught here rather than trusted.
+    let mut buf = String::new();
+    file.take(MAX_SOURCE_BYTES + 1)
+        .read_to_string(&mut buf)
+        .with_context(|| format!("reading {}", full.display()))?;
+    if buf.len() as u64 > MAX_SOURCE_BYTES {
+        bail!("{} grew past the {}-byte source view limit while reading", full.display(), MAX_SOURCE_BYTES);
+    }
+
+    let lines: Vec<String> = buf.lines().map(|line| line.to_string()).collect();
     if lines.len() > MAX_SOURCE_LINES {
         bail!(
             "{} has {} lines, over the {}-line source view limit",
@@ -224,6 +265,16 @@ pub fn load_source(working_dir: &str, path: &str) -> Result<Vec<String>> {
         );
     }
     Ok(lines)
+}
+
+/// Whether two `Metadata` values describe the SAME underlying file (same
+/// device, same inode) rather than merely files that happen to look alike.
+/// The one check a racing symlink-swap or file-replace cannot fake: even a
+/// same-sized, same-permissions replacement file gets a fresh inode.
+#[cfg(unix)]
+fn same_file(a: &std::fs::Metadata, b: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    a.dev() == b.dev() && a.ino() == b.ino()
 }
 
 /// Parse `git diff --no-color` unified output into file diffs.
@@ -921,6 +972,28 @@ index 1111111..2222222 100644
                 assert_eq!(line.origin, Origin::Add);
             }
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn same_file_detects_a_different_underlying_file_even_with_matching_size() {
+        // Regression (Codex P1): the symlink/size checks in load_source stat
+        // the PATH, then the read opens that same path again — a gap a
+        // racing path-swap could exploit (replace the path with a symlink,
+        // or a bigger file, between the check and the open). same_file is
+        // the guard that closes it: comparing the OPENED handle's own
+        // device/inode against what the pre-open check inspected, which a
+        // swap — even to a same-sized replacement — cannot fake.
+        let repo = TempRepo::new("same_file_check");
+        repo.write("a.txt", "hello");
+        repo.write("b.txt", "hello"); // same size, different underlying file
+
+        let meta_a = std::fs::symlink_metadata(repo.path.join("a.txt")).expect("stat a");
+        let meta_a_again = std::fs::symlink_metadata(repo.path.join("a.txt")).expect("stat a again");
+        let meta_b = std::fs::symlink_metadata(repo.path.join("b.txt")).expect("stat b");
+
+        assert!(same_file(&meta_a, &meta_a_again), "the same path stat'd twice must match");
+        assert!(!same_file(&meta_a, &meta_b), "two different files must not match, even same-sized");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1582,8 +1582,22 @@ fn summary_footer_text(buf: &str, width: usize) -> String {
     }
 }
 
+/// Shared by every footer state: the verdict keys that always apply.
+const GLOBAL_HINTS: &str = "a approve \u{b7} r request changes \u{b7} q cancel";
+
+/// The diff-focus footer's key hints, for the current position and view.
+/// The `n/p hunk` hint is diff-view-only: `handle_nav_key` makes `n`/`p`
+/// no-ops in source view (hunk jumps don't mean anything there), so
+/// advertising them in a mode where they do nothing would be stale,
+/// misleading help text — precisely in the newly added mode.
+fn diff_focus_footer(view: ViewMode, pos: &str) -> String {
+    let hunk_hint = if view == ViewMode::Diff { "n/p hunk \u{b7} " } else { "" };
+    format!(
+        " {pos} \u{b7} j/k move \u{b7} \u{2190}/\u{2192} pan \u{b7} d/u half page \u{b7} {hunk_hint}t view \u{b7} b files \u{b7} z zoom \u{b7} v select \u{b7} c comment \u{b7} x delete \u{b7} h/tab navigator \u{b7} {GLOBAL_HINTS}"
+    )
+}
+
 fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
-    const GLOBAL_HINTS: &str = "a approve \u{b7} r request changes \u{b7} q cancel";
     let text = match &app.input {
         // Input bars keep the END of a long buffer visible (that's where the
         // caret is) by trimming from the left with an ellipsis.
@@ -1601,9 +1615,7 @@ fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
                 // Position first: when the footer clips in a narrow pane,
                 // "where am I" survives and only the key hints get cut.
                 let pos = app.cursor_position().unwrap_or_default();
-                format!(
-                    " {pos} \u{b7} j/k move \u{b7} \u{2190}/\u{2192} pan \u{b7} d/u half page \u{b7} n/p hunk \u{b7} t view \u{b7} b files \u{b7} z zoom \u{b7} v select \u{b7} c comment \u{b7} x delete \u{b7} h/tab navigator \u{b7} {GLOBAL_HINTS}"
-                )
+                diff_focus_footer(app.view, &pos)
             }
         },
     };
@@ -2585,6 +2597,25 @@ mod tests {
         assert_eq!(tail_fit("short", 10), "short");
         assert_eq!(tail_fit("abcdefghij", 6), "\u{2026}fghij");
         assert!(tail_fit("abcdefghij", 6).chars().count() <= 6);
+    }
+
+    #[test]
+    fn diff_focus_footer_hides_the_hunk_hint_outside_diff_view() {
+        // Regression (Codex P1): the footer kept advertising `n/p hunk` in
+        // source view even though handle_nav_key makes both keys no-ops
+        // there (hunk jumps only mean something in the diff) — stale,
+        // misleading key help in the newly added mode.
+        let diff = diff_focus_footer(ViewMode::Diff, "a.txt:1");
+        assert!(diff.contains("n/p hunk"), "diff view must still advertise the hunk hint");
+
+        let source = diff_focus_footer(ViewMode::Source, "a.txt:1");
+        assert!(!source.contains("n/p hunk"), "source view must not advertise a disabled shortcut");
+
+        // Everything else stays present in both views.
+        for hint in ["j/k move", "t view", "v select", "c comment", "x delete", "a approve"] {
+            assert!(diff.contains(hint), "diff footer missing {hint:?}");
+            assert!(source.contains(hint), "source footer missing {hint:?}");
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -997,27 +997,48 @@ impl<'a> App<'a> {
                     KeyCode::Enter => {
                         let text = buf.trim().to_string();
                         if !text.is_empty() {
-                            // The comment's rows are rows of the CURRENT
-                            // view, so each view resolves them its own way.
-                            let resolved = match self.view {
-                                ViewMode::Diff => self
-                                    .files()
-                                    .get(self.nav.selected)
-                                    .map(|file| (file, flatten_rows(file)))
-                                    .and_then(|(file, rows)| {
-                                        resolve_annotation(
-                                            file, &rows, *row_start, *row_end, *tag, text,
-                                        )
-                                    }),
-                                ViewMode::Source => self
-                                    .resolve_source_annotation(*row_start, *row_end, *tag, text),
-                            };
-                            if let Some(annotation) = resolved {
-                                let item =
-                                    PendingAnnotation { file_idx: self.nav.selected, annotation };
-                                match *editing {
-                                    Some(idx) => self.pending[idx] = item,
-                                    None => self.pending.push(item),
+                            match *editing {
+                                // Editing keeps the original file/range/side
+                                // — only the comment and tag change. Rebuilding
+                                // the range from `row_start`/`row_end` here
+                                // would re-derive it from whatever the CURRENT
+                                // view's row span happens to be, which silently
+                                // narrows or shifts it whenever the annotation
+                                // was saved from a different view: a source
+                                // selection can cover lines the diff never
+                                // shows at all (far context, outside every
+                                // hunk), so re-resolving from diff rows alone
+                                // loses everything the diff doesn't display.
+                                Some(idx) => {
+                                    if let Some(p) = self.pending.get_mut(idx) {
+                                        p.annotation.tag = tag.map(|t| t.label().to_string());
+                                        p.annotation.comment = text;
+                                    }
+                                }
+                                None => {
+                                    // The comment's rows are rows of the
+                                    // CURRENT view, so each view resolves
+                                    // them its own way.
+                                    let resolved = match self.view {
+                                        ViewMode::Diff => self
+                                            .files()
+                                            .get(self.nav.selected)
+                                            .map(|file| (file, flatten_rows(file)))
+                                            .and_then(|(file, rows)| {
+                                                resolve_annotation(
+                                                    file, &rows, *row_start, *row_end, *tag, text,
+                                                )
+                                            }),
+                                        ViewMode::Source => self.resolve_source_annotation(
+                                            *row_start, *row_end, *tag, text,
+                                        ),
+                                    };
+                                    if let Some(annotation) = resolved {
+                                        self.pending.push(PendingAnnotation {
+                                            file_idx: self.nav.selected,
+                                            annotation,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -4029,6 +4050,108 @@ mod tests {
         assert!(app.view == ViewMode::Diff);
         assert_eq!(app.pending_anchor(0), Some((3, 3)));
         assert_eq!(app.diff.cursor, 3);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn editing_across_views_keeps_the_original_range_not_the_current_views_anchor() {
+        // Regression (Codex P1): saving an edit re-derived the annotation's
+        // protocol range from the CURRENT view's row span instead of keeping
+        // the one it was originally saved with. An annotation created in
+        // source view can cover lines that are only PARTLY present in the
+        // diff (most of the file isn't in any hunk); editing it from diff
+        // view then narrowed lines 4..=10 down to whatever subset of that
+        // range the diff actually shows — silently corrupting the range
+        // even when the edit changes nothing but hits Enter.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-cross-view-edit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        // 10 lines on disk so a source-view selection can span lines 4..=10.
+        let source = (1..=10).map(|n| format!("line{n}")).collect::<Vec<_>>().join("\n") + "\n";
+        std::fs::write(dir.join("a.txt"), source).expect("write source");
+
+        // The diff only shows new-side lines 5 and 6 — everything else in
+        // the file (including most of the 4..=10 range below) is far
+        // context, outside every hunk.
+        let file = FileDiff {
+            path: "a.txt".to_string(),
+            old_path: None,
+            status: FileStatus::Modified,
+            binary: false,
+            adds: 2,
+            dels: 0,
+            hunks: vec![Hunk {
+                header: "@@ -5,2 +5,2 @@".to_string(),
+                old_start: 5,
+                old_count: 2,
+                new_start: 5,
+                new_count: 2,
+                lines: vec![
+                    line(Origin::Add, None, Some(5), "line5"),
+                    line(Origin::Add, None, Some(6), "line6"),
+                ],
+            }],
+        };
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![file] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+
+        // Switch to source view and select source rows 3..=9 (lines 4..=10).
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Source);
+        app.diff.cursor = 3;
+        app.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), size);
+        for _ in 0..6 {
+            app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        }
+        assert_eq!(app.diff.cursor, 9);
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE), size);
+        for ch in "note".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE), size);
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+
+        assert_eq!(app.pending.len(), 1);
+        let original = (app.pending[0].annotation.lines.start, app.pending[0].annotation.lines.end);
+        assert_eq!(original, (4, 10), "source selection must save as the full line range");
+
+        // Back to diff view: this annotation only anchors to rows 1..=2
+        // there (lines 5 and 6 are all the diff shows).
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Diff);
+        assert_eq!(app.pending_anchor(0), Some((1, 2)), "diff view only shows part of the range");
+
+        // Reopen the SAME annotation for editing from diff view and save
+        // again with NO changes to the text — the range alone must survive.
+        app.diff.cursor = 1;
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE), size);
+        match &app.input {
+            Some(InputMode::Comment { editing, buf, .. }) => {
+                assert_eq!(*editing, Some(0));
+                assert_eq!(buf, "note");
+            }
+            other => panic!(
+                "expected comment input in edit mode, got a different state (variant present: {})",
+                other.is_some()
+            ),
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+
+        assert_eq!(app.pending.len(), 1, "editing must not duplicate the annotation");
+        let after_edit =
+            (app.pending[0].annotation.lines.start, app.pending[0].annotation.lines.end);
+        assert_eq!(
+            after_edit, original,
+            "editing from a different view must not change the saved range"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1882,8 +1882,21 @@ fn draw_diff(frame: &mut Frame, area: Rect, app: &App, file: Option<&FileDiff>) 
         lines.splice(at..at, group);
     }
 
-    let paragraph = Paragraph::new(lines).block(block).scroll((app.diff.scroll as u16, 0));
+    let paragraph = Paragraph::new(lines).block(block).scroll((scroll_row_u16(app.diff.scroll), 0));
     frame.render_widget(paragraph, area);
+}
+
+/// Narrow a display-space scroll offset to the `u16` `Paragraph::scroll`
+/// takes, WITHOUT wrapping. `MAX_SOURCE_LINES`'s margin for woven comment
+/// rows is a soft guideline sized for a realistic annotation count, not an
+/// enforced bound — a saved comment or the open editing box can add extra
+/// display rows without limit, so `scroll` itself could still exceed
+/// `u16::MAX` given enough of them. Clamping here means that pathological
+/// case stops scrolling further, rather than the offset wrapping and the
+/// pane silently rendering unrelated earlier rows while the cursor/footer
+/// still report the true, later position.
+fn scroll_row_u16(scroll: usize) -> u16 {
+    scroll.min(u16::MAX as usize) as u16
 }
 
 fn str_cols(s: &str) -> usize {
@@ -4280,6 +4293,22 @@ mod tests {
         assert_eq!(app.pan_cap(), diff_cap);
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scroll_row_u16_clamps_past_the_line_cap_margin_instead_of_wrapping() {
+        // Regression (Codex P1): MAX_SOURCE_LINES's margin bounds the
+        // source's BASE rows, but saved comments and the open editing box
+        // add unbounded extra display rows on top — a source near the line
+        // cap with enough wrapped comments can still push `scroll` past
+        // `u16::MAX`. A bare `as u16` cast would wrap that back down to a
+        // small offset and render unrelated earlier rows while the
+        // cursor/footer still report the true, later position; clamping
+        // instead just stops scrolling further, which is the safe failure.
+        assert_eq!(scroll_row_u16(0), 0);
+        assert_eq!(scroll_row_u16(65_535), 65_535, "must reach the real max exactly");
+        assert_eq!(scroll_row_u16(65_536), 65_535, "one past the max clamps, not wraps");
+        assert_eq!(scroll_row_u16(200_000), 65_535, "far past the max still clamps to it");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ use syntect::easy::HighlightLines;
 use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 
-use crate::diff::{DiffLine, DiffModel, FileDiff, FileStatus, Origin};
+use crate::diff::{load_source, DiffLine, DiffModel, FileDiff, FileStatus, Origin};
 use crate::protocol::{Annotation, LineRange, ReviewRequest, Side, Verdict};
 
 /// What the reviewer decided, handed back to `pane.rs`.
@@ -130,6 +130,16 @@ impl Drop for TermGuard {
 enum Focus {
     Navigator,
     Diff,
+}
+
+/// What the right-hand pane renders: the unified diff, or the selected
+/// file's post-change source. Global rather than per-file — `t` switches the
+/// whole review's reading mode, and carrying it per file would make the same
+/// key mean different things on different rows of the navigator.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ViewMode {
+    Diff,
+    Source,
 }
 
 /// File-list selection, decoupled from rendering so it's plain and testable.
@@ -398,13 +408,16 @@ enum InputMode {
 }
 
 /// An annotation the reviewer has left but not yet submitted with a verdict.
-/// `row_start`/`row_end` are flattened-row indices (inclusive) into
-/// `files[file_idx]`'s rows — used for gutter markers and for finding the
-/// annotation under the cursor to edit or delete.
+///
+/// The protocol annotation's file/line range is the ONLY anchor stored: it is
+/// what crosses the wire, and it is view-independent. Display anchors (which
+/// rows to dot, where to weave the note) are derived per view on demand by
+/// `App::pending_anchor`, so one annotation lands in the right place in both
+/// the diff and the source view — and an annotation with no place in the
+/// current view (an old-side one in source view, say) simply doesn't draw,
+/// while still counting and still going back to the agent.
 struct PendingAnnotation {
     file_idx: usize,
-    row_start: usize,
-    row_end: usize,
     annotation: Annotation,
 }
 
@@ -454,6 +467,84 @@ fn resolve_annotation(
         tag: tag.map(|t| t.label().to_string()),
         comment,
     })
+}
+
+/// The inverse of `resolve_annotation` for the DIFF view: which flattened
+/// rows an annotation covers. A row counts when it's a `DiffRow::Line` whose
+/// number on the annotation's own side falls inside its line range; the
+/// result is the (min, max) of those row indices. `None` means the
+/// annotation has no place in this view at all — its lines aren't part of
+/// any hunk (context far from the change, or the wrong side of a rename).
+fn annotation_rows(annotation: &Annotation, rows: &[DiffRow]) -> Option<(usize, usize)> {
+    let mut first: Option<usize> = None;
+    let mut last: Option<usize> = None;
+    for (idx, row) in rows.iter().enumerate() {
+        let DiffRow::Line(line) = row else { continue };
+        let side_no = match annotation.side {
+            Side::New => line.new_no,
+            Side::Old => line.old_no,
+        };
+        let Some(no) = side_no else { continue };
+        if no >= annotation.lines.start && no <= annotation.lines.end {
+            first.get_or_insert(idx);
+            last = Some(idx);
+        }
+    }
+    Some((first?, last?))
+}
+
+/// The same mapping for the SOURCE view, where it's pure arithmetic: row `i`
+/// is line `i + 1` of the file on disk. Old-side annotations have no place
+/// here (the source IS the new side), and neither does anything at all when
+/// the file has no source view (`line_count == 0`). Ranges reaching past the
+/// end of the file clamp to its last row rather than vanishing.
+fn source_annotation_rows(annotation: &Annotation, line_count: usize) -> Option<(usize, usize)> {
+    if annotation.side != Side::New || line_count == 0 {
+        return None;
+    }
+    let last = line_count - 1;
+    let start = (annotation.lines.start.max(1) as usize - 1).min(last);
+    let end = (annotation.lines.end.max(1) as usize - 1).min(last).max(start);
+    Some((start, end))
+}
+
+/// Per-view context for turning annotations into display anchors: the
+/// flattened rows in diff view, the source file's line count in source view.
+/// Built once per pass so a file full of annotations doesn't re-flatten the
+/// diff once per annotation.
+enum ViewAnchors<'a> {
+    Diff(Vec<DiffRow<'a>>),
+    Source(usize),
+}
+
+impl ViewAnchors<'_> {
+    fn anchor(&self, annotation: &Annotation) -> Option<(usize, usize)> {
+        match self {
+            ViewAnchors::Diff(rows) => annotation_rows(annotation, rows),
+            ViewAnchors::Source(line_count) => source_annotation_rows(annotation, *line_count),
+        }
+    }
+}
+
+/// Cursor remap, diff → source: the source row showing the same line. Rows
+/// with no new-side line (removed lines, hunk headers, placeholders) have no
+/// counterpart, so the cursor goes to the top of the file.
+fn diff_row_to_source_row(rows: &[DiffRow], cursor: usize) -> usize {
+    match rows.get(cursor) {
+        Some(DiffRow::Line(line)) => {
+            line.new_no.map(|n| n.saturating_sub(1) as usize).unwrap_or(0)
+        }
+        _ => 0,
+    }
+}
+
+/// Cursor remap, source → diff: the first diff row showing that line. A line
+/// outside every hunk isn't in the diff at all, so the cursor goes to the top.
+fn source_row_to_diff_row(rows: &[DiffRow], cursor: usize) -> usize {
+    let target = cursor as u32 + 1;
+    rows.iter()
+        .position(|row| matches!(row, DiffRow::Line(line) if line.new_no == Some(target)))
+        .unwrap_or(0)
 }
 
 /// Visible diff rows, derived from the terminal size via the SAME split
@@ -558,6 +649,24 @@ struct App<'a> {
     /// on demand. Never invalidated — the model is immutable for the life
     /// of the UI.
     row_cache: HashMap<usize, Vec<Line<'static>>>,
+    /// Diff or source in the right-hand pane; `t` toggles.
+    view: ViewMode,
+    /// Highlighted source rows per file, keyed by index into `model.files`.
+    /// `Err(reason)` for files that have no source view (deleted, binary,
+    /// unreadable) — the reason is what the placeholder row shows. Unlike
+    /// `row_cache` this is filled LAZILY, from key/mouse handlers only
+    /// (`ensure_source_loaded`): reading every file off disk up front would
+    /// be wasted I/O for a mode most reviews never enter, and `draw` borrows
+    /// `App` immutably so it can never populate a cache itself.
+    source_cache: HashMap<usize, Result<SourceFile, String>>,
+}
+
+/// One file's source view: its highlighted rows and how many lines it has
+/// (the same number, kept alongside so row-count queries don't depend on the
+/// rendered rows).
+struct SourceFile {
+    lines: Vec<Line<'static>>,
+    count: usize,
 }
 
 impl<'a> App<'a> {
@@ -581,6 +690,8 @@ impl<'a> App<'a> {
             show_navigator: true,
             pending: Vec::new(),
             row_cache,
+            view: ViewMode::Diff,
+            source_cache: HashMap::new(),
         }
     }
 
@@ -599,9 +710,171 @@ impl<'a> App<'a> {
         self.selected_file().map(flatten_rows).unwrap_or_default()
     }
 
+    /// Rows the pane currently addresses — what the cursor moves over and
+    /// what mouse hits clamp to. Diff rows or source lines depending on the
+    /// view; the `(no source view: …)` placeholder counts as one row.
+    fn view_row_count(&self) -> usize {
+        match self.view {
+            ViewMode::Diff => self.diff_rows().len(),
+            ViewMode::Source => self.source_row_count(),
+        }
+    }
+
+    /// Lines in the selected file's source, or 0 when it has no source view
+    /// (no file selected, deleted, binary, unreadable, or not yet loaded) —
+    /// which is exactly the condition that makes source annotations inert.
+    fn source_line_count(&self) -> usize {
+        match self.source_cache.get(&self.nav.selected) {
+            Some(Ok(source)) => source.count,
+            _ => 0,
+        }
+    }
+
+    fn source_row_count(&self) -> usize {
+        if self.selected_file().is_none() {
+            return 0;
+        }
+        match self.source_cache.get(&self.nav.selected) {
+            Some(Ok(source)) => source.count,
+            // No source view: the placeholder row still occupies one row.
+            _ => 1,
+        }
+    }
+
+    /// The pane's display rows for the current view, owned and ready to
+    /// patch (gutter dots, selection, cursor) before rendering.
+    fn view_lines(&self) -> Vec<Line<'static>> {
+        match self.view {
+            ViewMode::Diff => self.row_cache.get(&self.nav.selected).cloned().unwrap_or_default(),
+            ViewMode::Source => match self.source_cache.get(&self.nav.selected) {
+                Some(Ok(source)) => source.lines.clone(),
+                Some(Err(reason)) => vec![source_placeholder_line(reason)],
+                // Only reachable if a draw beats the handler that loads;
+                // still renders something rather than an empty pane.
+                None => vec![source_placeholder_line("not loaded")],
+            },
+        }
+    }
+
+    /// Context for resolving annotations to display rows in the current view.
+    fn view_anchors(&self) -> ViewAnchors<'_> {
+        match self.view {
+            ViewMode::Diff => ViewAnchors::Diff(self.diff_rows()),
+            ViewMode::Source => ViewAnchors::Source(self.source_line_count()),
+        }
+    }
+
+    /// Display rows `pending[idx]` covers in the CURRENT view, or `None` when
+    /// it belongs to another file or isn't representable here. The single
+    /// place the view dispatch happens: gutter dots, note weaving, the
+    /// display map, edit-under-cursor and delete all go through it.
+    fn pending_anchor(&self, idx: usize) -> Option<(usize, usize)> {
+        let pending = self.pending.get(idx)?;
+        if pending.file_idx != self.nav.selected {
+            return None;
+        }
+        self.view_anchors().anchor(&pending.annotation)
+    }
+
+    /// Index of the pending annotation covering `row` in the current view.
+    fn pending_at_row(&self, row: usize) -> Option<usize> {
+        let anchors = self.view_anchors();
+        self.pending.iter().position(|p| {
+            p.file_idx == self.nav.selected
+                && matches!(anchors.anchor(&p.annotation), Some((start, end)) if start <= row && row <= end)
+        })
+    }
+
     /// All pending annotations, in creation order, cloned for handoff.
     fn pending_annotations(&self) -> Vec<Annotation> {
         self.pending.iter().map(|p| p.annotation.clone()).collect()
+    }
+
+    /// Load (once) the selected file's source rows into the cache. Called
+    /// from handlers only — never from `draw`.
+    fn ensure_source_loaded(&mut self) {
+        let idx = self.nav.selected;
+        if self.source_cache.contains_key(&idx) {
+            return;
+        }
+        // Copied out so the immutable borrow of the model ends before the
+        // cache insert below.
+        let Some((path, status, binary)) =
+            self.files().get(idx).map(|f| (f.path.clone(), f.status, f.binary))
+        else {
+            return;
+        };
+        let entry = if status == FileStatus::Deleted {
+            Err("file deleted".to_string())
+        } else if binary {
+            Err("binary file".to_string())
+        } else {
+            match load_source(&self.request.working_dir, &path) {
+                Ok(lines) => Ok(SourceFile {
+                    lines: highlight_source_rows(highlighter(), &path, &lines),
+                    count: lines.len(),
+                }),
+                Err(err) => Err(err.root_cause().to_string()),
+            }
+        };
+        self.source_cache.insert(idx, entry);
+    }
+
+    /// After the navigator selection changes: reset the pane and, in source
+    /// view, make sure the newly selected file's source is in the cache.
+    fn file_changed(&mut self) {
+        self.diff.reset();
+        if self.view == ViewMode::Source {
+            self.ensure_source_loaded();
+        }
+    }
+
+    /// `t` in diff focus: switch views, carrying the cursor to the row
+    /// showing the same line of code, and starting the new view unpanned.
+    fn toggle_view(&mut self, term_size: Size) {
+        match self.view {
+            ViewMode::Diff => {
+                let target = diff_row_to_source_row(&self.diff_rows(), self.diff.cursor);
+                self.view = ViewMode::Source;
+                self.ensure_source_loaded();
+                self.diff.cursor = target.min(self.source_row_count().saturating_sub(1));
+            }
+            ViewMode::Source => {
+                self.view = ViewMode::Diff;
+                self.diff.cursor = source_row_to_diff_row(&self.diff_rows(), self.diff.cursor);
+            }
+        }
+        // A live `v` selection is anchored in the OLD view's row space, so
+        // it would paint an unrelated range here: drop it with the view.
+        self.visual_anchor = None;
+        self.diff.hscroll = 0;
+        self.diff.scroll = 0;
+        self.ensure_cursor_visible(term_size);
+    }
+
+    /// Source-view counterpart to `resolve_annotation`: no row scan needed,
+    /// since source row `i` simply IS new-side line `i + 1`.
+    fn resolve_source_annotation(
+        &self,
+        row_start: usize,
+        row_end: usize,
+        tag: Option<Tag>,
+        comment: String,
+    ) -> Option<Annotation> {
+        let file = self.selected_file()?;
+        let count = self.source_line_count();
+        if count == 0 {
+            return None;
+        }
+        let start = row_start.min(count - 1);
+        let end = row_end.min(count - 1).max(start);
+        Some(Annotation {
+            file: file.path.clone(),
+            lines: LineRange { start: start as u32 + 1, end: end as u32 + 1 },
+            side: Side::New,
+            tag: tag.map(|t| t.label().to_string()),
+            comment,
+        })
     }
 
     /// Handle one key event. Returns `Some(outcome)` once the reviewer has
@@ -651,20 +924,24 @@ impl<'a> App<'a> {
                     KeyCode::Enter => {
                         let text = buf.trim().to_string();
                         if !text.is_empty() {
-                            let resolved = self
-                                .files()
-                                .get(self.nav.selected)
-                                .map(|file| (file, flatten_rows(file)))
-                                .and_then(|(file, rows)| {
-                                    resolve_annotation(file, &rows, *row_start, *row_end, *tag, text)
-                                });
+                            // The comment's rows are rows of the CURRENT
+                            // view, so each view resolves them its own way.
+                            let resolved = match self.view {
+                                ViewMode::Diff => self
+                                    .files()
+                                    .get(self.nav.selected)
+                                    .map(|file| (file, flatten_rows(file)))
+                                    .and_then(|(file, rows)| {
+                                        resolve_annotation(
+                                            file, &rows, *row_start, *row_end, *tag, text,
+                                        )
+                                    }),
+                                ViewMode::Source => self
+                                    .resolve_source_annotation(*row_start, *row_end, *tag, text),
+                            };
                             if let Some(annotation) = resolved {
-                                let item = PendingAnnotation {
-                                    file_idx: self.nav.selected,
-                                    row_start: *row_start,
-                                    row_end: *row_end,
-                                    annotation,
-                                };
+                                let item =
+                                    PendingAnnotation { file_idx: self.nav.selected, annotation };
                                 match *editing {
                                     Some(idx) => self.pending[idx] = item,
                                     None => self.pending.push(item),
@@ -757,14 +1034,18 @@ impl<'a> App<'a> {
             _ => None,
         };
 
+        let anchors = self.view_anchors();
         let mut ends: Vec<usize> = Vec::new();
         for (i, p) in self.pending.iter().enumerate().filter(|(_, p)| p.file_idx == self.nav.selected)
         {
             if Some(i) == editing_idx {
                 continue;
             }
+            // Annotations with no anchor in this view aren't drawn, so they
+            // occupy no display rows either.
+            let Some((_, row_end)) = anchors.anchor(&p.annotation) else { continue };
             let h = comment_height(p.annotation.tag.as_deref(), &p.annotation.comment, inner_width);
-            ends.extend(std::iter::repeat(p.row_end).take(h));
+            ends.extend(std::iter::repeat(row_end).take(h));
         }
         if let Some(InputMode::Comment { buf, row_end, .. }) = &self.input {
             // Both a fresh comment and an edit weave the box (new AND edit).
@@ -808,7 +1089,7 @@ impl<'a> App<'a> {
                         self.nav.up();
                     }
                     if self.nav.selected != before {
-                        self.diff.reset();
+                        self.file_changed();
                     }
                 } else if in_diff {
                     self.wheel_diff(down, term_size);
@@ -820,10 +1101,10 @@ impl<'a> App<'a> {
                         self.focus = Focus::Navigator;
                         if idx != self.nav.selected {
                             self.nav.selected = idx;
-                            self.diff.reset();
+                            self.file_changed();
                         }
                     }
-                } else if in_diff && !self.diff_rows().is_empty() {
+                } else if in_diff && self.view_row_count() > 0 {
                     self.focus = Focus::Diff;
                     // A fresh click always starts over: cursor moves, any
                     // keyboard/mouse selection is discarded, and the pressed
@@ -836,7 +1117,7 @@ impl<'a> App<'a> {
             }
             MouseEventKind::Drag(MouseButton::Left) => {
                 if let Some(origin) = self.drag_origin {
-                    if self.diff_rows().is_empty() {
+                    if self.view_row_count() == 0 {
                         return;
                     }
                     let base = self.diff_base_at(mouse.row, diff_rect);
@@ -868,7 +1149,7 @@ impl<'a> App<'a> {
     /// only when it would leave the visible area (editor-style), so plain
     /// reading scrolls never disturb the cursor.
     fn wheel_diff(&mut self, down: bool, term_size: Size) {
-        let base_count = self.diff_rows().len();
+        let base_count = self.view_row_count();
         if base_count == 0 {
             return;
         }
@@ -908,7 +1189,7 @@ impl<'a> App<'a> {
     /// Base row under a mouse row in the diff pane; rows outside the inner
     /// area clamp to its edges so drags past the border keep selecting.
     fn diff_base_at(&self, mouse_row: u16, diff_rect: Rect) -> usize {
-        let base_count = self.diff_rows().len();
+        let base_count = self.view_row_count();
         let map = self.disp_map((diff_rect.width.saturating_sub(2)).max(1) as usize);
         let inner_y = diff_rect.y + 1;
         let inner_h = diff_rect.height.saturating_sub(2).max(1);
@@ -935,19 +1216,17 @@ impl<'a> App<'a> {
             return;
         }
 
-        let selected = self.nav.selected;
-        if let Some(idx) = self
-            .pending
-            .iter()
-            .position(|p| p.file_idx == selected && p.row_start <= cursor && cursor <= p.row_end)
-        {
+        if let Some(idx) = self.pending_at_row(cursor) {
+            // Reopen at the annotation's anchor in THIS view, not wherever
+            // it was first written.
+            let (row_start, row_end) = self.pending_anchor(idx).unwrap_or((cursor, cursor));
             let p = &self.pending[idx];
             self.input = Some(InputMode::Comment {
                 buf: p.annotation.comment.clone(),
                 tag: p.annotation.tag.as_deref().and_then(Tag::from_label),
                 editing: Some(idx),
-                row_start: p.row_start,
-                row_end: p.row_end,
+                row_start,
+                row_end,
             });
             return;
         }
@@ -964,13 +1243,7 @@ impl<'a> App<'a> {
     /// `x` in diff focus, input closed: delete the pending annotation
     /// covering the cursor row on the current file, if any.
     fn delete_pending_at_cursor(&mut self) {
-        let cursor = self.diff.cursor;
-        let selected = self.nav.selected;
-        if let Some(idx) = self
-            .pending
-            .iter()
-            .position(|p| p.file_idx == selected && p.row_start <= cursor && cursor <= p.row_end)
-        {
+        if let Some(idx) = self.pending_at_row(self.diff.cursor) {
             self.pending.remove(idx);
         }
     }
@@ -991,11 +1264,11 @@ impl<'a> App<'a> {
                     _ => {}
                 }
                 if self.nav.selected != before {
-                    self.diff.reset();
+                    self.file_changed();
                 }
             }
             Focus::Diff => {
-                let row_count = self.diff_rows().len();
+                let row_count = self.view_row_count();
                 match key.code {
                     KeyCode::Char('j') | KeyCode::Down => self.diff.down(row_count),
                     KeyCode::Char('k') | KeyCode::Up => self.diff.up(),
@@ -1005,10 +1278,11 @@ impl<'a> App<'a> {
                     KeyCode::Char('u') | KeyCode::PageUp => {
                         self.diff.page_up(half_page(term_size, self.show_navigator))
                     }
-                    KeyCode::Char('n') => {
+                    // Hunk jumps only mean something in the diff view.
+                    KeyCode::Char('n') if self.view == ViewMode::Diff => {
                         self.diff.next_hunk(&hunk_row_indices(&self.diff_rows()))
                     }
-                    KeyCode::Char('p') => {
+                    KeyCode::Char('p') if self.view == ViewMode::Diff => {
                         self.diff.prev_hunk(&hunk_row_indices(&self.diff_rows()))
                     }
                     KeyCode::Char('g') => self.diff.top(),
@@ -1029,6 +1303,7 @@ impl<'a> App<'a> {
                     }
                     KeyCode::Char('c') => self.open_comment_input(),
                     KeyCode::Char('x') => self.delete_pending_at_cursor(),
+                    KeyCode::Char('t') => self.toggle_view(term_size),
                     _ => {}
                 }
             }
@@ -1040,6 +1315,15 @@ impl<'a> App<'a> {
     /// lines fall back to the old side, marked as such.
     fn cursor_position(&self) -> Option<String> {
         let file = self.selected_file()?;
+        if self.view == ViewMode::Source {
+            // Source rows ARE lines, so the position is exact — unless the
+            // file has no source view, where the single row is a placeholder.
+            return Some(if self.source_line_count() > 0 {
+                format!("{}:{}", file.path, self.diff.cursor + 1)
+            } else {
+                file.path.clone()
+            });
+        }
         let rows = self.diff_rows();
         match rows.get(self.diff.cursor)? {
             DiffRow::Line(line) => match (line.new_no, line.old_no) {
@@ -1123,7 +1407,7 @@ fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
                 // "where am I" survives and only the key hints get cut.
                 let pos = app.cursor_position().unwrap_or_default();
                 format!(
-                    " {pos} \u{b7} j/k move \u{b7} \u{2190}/\u{2192} pan \u{b7} d/u half page \u{b7} n/p hunk \u{b7} b files \u{b7} z zoom \u{b7} v select \u{b7} c comment \u{b7} x delete \u{b7} h/tab navigator \u{b7} {GLOBAL_HINTS}"
+                    " {pos} \u{b7} j/k move \u{b7} \u{2190}/\u{2192} pan \u{b7} d/u half page \u{b7} n/p hunk \u{b7} t view \u{b7} b files \u{b7} z zoom \u{b7} v select \u{b7} c comment \u{b7} x delete \u{b7} h/tab navigator \u{b7} {GLOBAL_HINTS}"
                 )
             }
         },
@@ -1236,7 +1520,10 @@ fn nav_item(file: &FileDiff) -> ListItem<'_> {
 }
 
 fn draw_diff(frame: &mut Frame, area: Rect, app: &App, file: Option<&FileDiff>) {
-    let title = file.map(file_display_path).unwrap_or_else(|| "diff".to_string());
+    let mut title = file.map(file_display_path).unwrap_or_else(|| "diff".to_string());
+    if app.view == ViewMode::Source {
+        title.push_str(" [source]");
+    }
     let block = pane_block(title, app.focus == Focus::Diff);
 
     if file.is_none() {
@@ -1244,16 +1531,23 @@ fn draw_diff(frame: &mut Frame, area: Rect, app: &App, file: Option<&FileDiff>) 
         return;
     }
 
-    // Pre-highlighted in `App::new`; drawing just clones the cached, owned
-    // lines rather than re-running syntect on every frame.
-    let mut lines: Vec<Line> = app.row_cache.get(&app.nav.selected).cloned().unwrap_or_default();
+    // Pre-highlighted (diff rows in `App::new`, source rows on first `t`);
+    // drawing just clones the cached, owned lines rather than re-running
+    // syntect on every frame.
+    let mut lines: Vec<Line> = app.view_lines();
+
+    // Where each annotation sits in THIS view; annotations with no anchor
+    // here (an old-side one in source view, or lines outside every hunk in
+    // diff view) draw nothing at all.
+    let anchors = app.view_anchors();
 
     // Gutter markers: one per row covered by a pending annotation on this
     // file, colored by tag. Overwrites the first character of the gutter
     // span in place so the column width doesn't shift.
     for pending in app.pending.iter().filter(|p| p.file_idx == app.nav.selected) {
+        let Some((row_start, row_end)) = anchors.anchor(&pending.annotation) else { continue };
         let color = tag_color(pending.annotation.tag.as_deref());
-        for row in pending.row_start..=pending.row_end {
+        for row in row_start..=row_end {
             if let Some(line) = lines.get_mut(row) {
                 if let Some(span) = line.spans.first_mut() {
                     let mut chars: Vec<char> = span.content.chars().collect();
@@ -1331,7 +1625,8 @@ fn draw_diff(frame: &mut Frame, area: Rect, app: &App, file: Option<&FileDiff>) 
         if Some(i) == editing_idx {
             continue;
         }
-        groups.entry(p.row_end).or_default().extend(inline_comment_lines(
+        let Some((_, row_end)) = anchors.anchor(&p.annotation) else { continue };
+        groups.entry(row_end).or_default().extend(inline_comment_lines(
             p.annotation.tag.as_deref(),
             &p.annotation.comment,
             false,
@@ -1669,6 +1964,70 @@ fn highlight_file_rows(hl: &'static Highlighter, file: &FileDiff) -> Vec<Line<'s
         }
     }
     out
+}
+
+/// Width of the source view's line-number field. The diff gutter renders
+/// two 4-wide numbers, a separator and a trailing space, then a 1-column
+/// origin marker (11 columns before the code); the source view spends the
+/// same 11 on `{n:>8}` + two spaces + the one-space spacer span, so code
+/// starts in the same column whichever view you're in.
+const SOURCE_NUMBER_WIDTH: usize = 8;
+
+/// Highlight a whole source file into display-ready rows, one per line.
+///
+/// Unlike the diff (highlighted hunk by hunk, each hunk mixing two file
+/// states), the source view feeds one `HighlightLines` the entire file top
+/// to bottom — the highlighter sees exactly the text the parser expects, so
+/// multi-line strings, block comments and nested blocks all come out right.
+///
+/// Row layout is `[gutter, one-space spacer, content…]`, deliberately at
+/// least three spans: `draw_diff` pins the first two spans of any row with
+/// three or more when panning horizontally, which keeps the line numbers
+/// on screen exactly as the diff view's gutter+marker do. Blank lines get
+/// an empty content span so they hit that rule too.
+fn highlight_source_rows(
+    hl: &'static Highlighter,
+    path: &str,
+    lines: &[String],
+) -> Vec<Line<'static>> {
+    let syntax = syntax_for_path(hl, path);
+    let mut state = HighlightLines::new(syntax, &hl.theme);
+    let mut out = Vec::with_capacity(lines.len());
+
+    for (i, text) in lines.iter().enumerate() {
+        let mut spans = vec![
+            Span::styled(
+                format!("{:>width$}  ", i + 1, width = SOURCE_NUMBER_WIDTH),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::raw(" "),
+        ];
+
+        // Same newline dance as the diff highlighter: syntect needs the
+        // trailing newline for state tracking, and it must not be rendered.
+        let mut fed = text.clone();
+        fed.push('\n');
+        let ranges = state.highlight_line(&fed, &hl.syntax_set).unwrap_or_default();
+        for (style, chunk) in ranges {
+            let chunk = chunk.strip_suffix('\n').unwrap_or(chunk);
+            if chunk.is_empty() {
+                continue;
+            }
+            let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+            spans.push(Span::styled(chunk.to_string(), Style::default().fg(fg)));
+        }
+        if spans.len() == 2 {
+            // Blank line: still needs a content span to keep the gutter pinned.
+            spans.push(Span::raw(""));
+        }
+        out.push(Line::from(spans));
+    }
+    out
+}
+
+/// The single row shown instead of source for files that have none.
+fn source_placeholder_line(reason: &str) -> Line<'static> {
+    Line::styled(format!("(no source view: {reason})"), Style::default().fg(Color::DarkGray))
 }
 
 /// Highlight one diff line's content and compose it with the existing
@@ -2254,8 +2613,6 @@ mod tests {
         let mut app = App::new(&request, &model);
         app.pending.push(PendingAnnotation {
             file_idx: 0,
-            row_start: 1,
-            row_end: 1,
             annotation: Annotation {
                 file: "src/lib.rs".to_string(),
                 lines: LineRange { start: 2, end: 2 },
@@ -2266,19 +2623,22 @@ mod tests {
         });
 
         let inner_width = 40;
+        // The annotation carries no display anchor of its own: new-side line
+        // 2 is the add row, flattened row 2 (header, context, add, …).
+        assert_eq!(app.pending_anchor(0), Some((2, 2)));
 
         // Not editing: disp_map counts the saved annotation's own rows.
         let saved_h = comment_height(Some("fix"), "a saved note", inner_width);
         let map = app.disp_map(inner_width);
-        assert_eq!(map.extra_at(1), saved_h);
+        assert_eq!(map.extra_at(2), saved_h);
 
-        // Open edit mode on that same annotation (row_start == row_end == 1).
+        // Open edit mode on that same annotation (at its anchor row).
         app.input = Some(InputMode::Comment {
             buf: "editing now, with a much longer replacement comment".to_string(),
             tag: Some(Tag::Fix),
             editing: Some(0),
-            row_start: 1,
-            row_end: 1,
+            row_start: 2,
+            row_end: 2,
         });
 
         // The saved annotation's rows are gone from the map; only the
@@ -2288,8 +2648,211 @@ mod tests {
             inner_width,
         );
         let map = app.disp_map(inner_width);
-        assert_eq!(map.extra_at(1), box_h);
+        assert_eq!(map.extra_at(2), box_h);
         assert_eq!(map.total(app.diff_rows().len()), app.diff_rows().len() + box_h);
+    }
+
+    // --- annotation anchoring (protocol lines -> display rows) ----------
+
+    /// An annotation on `sample_file`, spelled by side and line range.
+    fn anno(side: Side, start: u32, end: u32) -> Annotation {
+        Annotation {
+            file: "src/lib.rs".to_string(),
+            lines: LineRange { start, end },
+            side,
+            tag: None,
+            comment: "why".to_string(),
+        }
+    }
+
+    #[test]
+    fn annotation_rows_new_side_range_spans_add_and_context_rows() {
+        let file = sample_file();
+        let rows = flatten_rows(&file);
+        // New-side lines 2..=3 are the add row (row 2) and the context row
+        // after it (row 3) — the range covers both, and the header above
+        // them is not a Line row so it never anchors.
+        assert_eq!(annotation_rows(&anno(Side::New, 2, 3), &rows), Some((2, 3)));
+        // A single line still yields a degenerate (min, max).
+        assert_eq!(annotation_rows(&anno(Side::New, 12, 12), &rows), Some((7, 7)));
+    }
+
+    #[test]
+    fn annotation_rows_old_side_anchors_to_the_remove_row() {
+        let file = sample_file();
+        let rows = flatten_rows(&file);
+        // Old-side line 10 exists only on the removed line (row 5); the add
+        // row next to it carries new_no 11, which the Old side ignores.
+        assert_eq!(annotation_rows(&anno(Side::Old, 10, 10), &rows), Some((5, 5)));
+    }
+
+    #[test]
+    fn annotation_rows_returns_none_when_no_row_matches() {
+        let file = sample_file();
+        let rows = flatten_rows(&file);
+        // New-side lines 4..=10 fall between the two hunks: not in the diff
+        // at all, so there is nothing to dot or weave under.
+        assert!(annotation_rows(&anno(Side::New, 4, 10), &rows).is_none());
+        // Old-side line 3 likewise: the old file's line 3 is not shown.
+        assert!(annotation_rows(&anno(Side::Old, 3, 3), &rows).is_none());
+    }
+
+    #[test]
+    fn source_annotation_rows_are_line_numbers_clamped_to_the_file() {
+        // Lines 3..=5 of a 10-line file are rows 2..=4.
+        assert_eq!(source_annotation_rows(&anno(Side::New, 3, 5), 10), Some((2, 4)));
+        // Shorter file: the range clamps to its last row instead of vanishing.
+        assert_eq!(source_annotation_rows(&anno(Side::New, 3, 5), 4), Some((2, 3)));
+        assert_eq!(source_annotation_rows(&anno(Side::New, 3, 5), 3), Some((2, 2)));
+        // Old-side annotations have no place in the source view, and neither
+        // does anything when there is no source (deleted/binary/unreadable).
+        assert!(source_annotation_rows(&anno(Side::Old, 3, 5), 10).is_none());
+        assert!(source_annotation_rows(&anno(Side::New, 3, 5), 0).is_none());
+    }
+
+    #[test]
+    fn cursor_remaps_between_diff_rows_and_source_lines() {
+        let file = sample_file();
+        let rows = flatten_rows(&file);
+
+        // Diff -> source: the row's new-side line, zero-based.
+        assert_eq!(diff_row_to_source_row(&rows, 2), 1); // add, new line 2
+        assert_eq!(diff_row_to_source_row(&rows, 7), 11); // context, new line 12
+        // Rows with no new side (hunk header, removed line) fall to the top.
+        assert_eq!(diff_row_to_source_row(&rows, 0), 0);
+        assert_eq!(diff_row_to_source_row(&rows, 5), 0);
+        assert_eq!(diff_row_to_source_row(&rows, 99), 0);
+
+        // Source -> diff: the first row showing that line.
+        assert_eq!(source_row_to_diff_row(&rows, 1), 2); // line 2 -> add row
+        assert_eq!(source_row_to_diff_row(&rows, 11), 7); // line 12 -> last row
+        assert_eq!(source_row_to_diff_row(&rows, 0), 1); // line 1 -> first context
+        // A line outside every hunk isn't in the diff: fall to the top.
+        assert_eq!(source_row_to_diff_row(&rows, 5), 0);
+    }
+
+    // --- source view ----------------------------------------------------
+
+    #[test]
+    fn source_rows_carry_gutter_spacer_and_content_spans() {
+        let lines: Vec<String> = ["fn main() {", "", "    let x = 1;"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let rows = highlight_source_rows(highlighter(), "src/lib.rs", &lines);
+        assert_eq!(rows.len(), 3);
+
+        for (i, row) in rows.iter().enumerate() {
+            // [gutter, spacer, content…] — at least three spans on EVERY row
+            // (blank lines included) so `draw_diff`'s `spans.len() >= 3 -> pin
+            // 2` rule keeps the gutter and spacer put while panning.
+            assert!(row.spans.len() >= 3, "row {i} has {} spans", row.spans.len());
+            let gutter = row.spans[0].content.as_ref();
+            assert_eq!(gutter.trim(), (i + 1).to_string(), "row {i} gutter");
+            assert_eq!(gutter.chars().count(), SOURCE_NUMBER_WIDTH + 2);
+            assert_eq!(row.spans[1].content.as_ref(), " ");
+            let content: String = row.spans[2..].iter().map(|s| s.content.as_ref()).collect();
+            assert_eq!(content, lines[i], "row {i} content");
+        }
+
+        // The pin actually holds: panning past the whole line leaves the
+        // gutter and spacer untouched.
+        let mut row = rows[0].clone();
+        let pinned = if row.spans.len() >= 3 { 2 } else { 0 };
+        pan_and_clip(&mut row, 500, 80, pinned);
+        assert_eq!(row.spans[0].content.trim(), "1");
+        assert_eq!(row.spans[1].content.as_ref(), " ");
+    }
+
+    #[test]
+    fn source_view_toggles_and_annotates_by_line_number() {
+        // A real file on disk: the source view reads the worktree, which IS
+        // the new side of the diff whatever the baseline was.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-source-view-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("src")).expect("temp dir");
+        std::fs::write(
+            dir.join("src/lib.rs"),
+            "fn main() {\n    setup();\n    run();\n}\n",
+        )
+        .expect("write source");
+
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+
+        // `t` switches to source and loads the file: 4 rows, one per line.
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Source);
+        assert_eq!(app.view_row_count(), 4);
+
+        // Comment on source row 2, i.e. new-side line 3.
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        assert_eq!(app.diff.cursor, 2);
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE), size);
+        for ch in "here".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE), size);
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+
+        assert_eq!(app.pending.len(), 1);
+        let saved = &app.pending[0].annotation;
+        assert_eq!(saved.side, Side::New);
+        assert_eq!((saved.lines.start, saved.lines.end), (3, 3));
+        assert_eq!(saved.file, "src/lib.rs");
+        assert_eq!(app.pending_anchor(0), Some((2, 2)));
+
+        // Back to the diff: the SAME annotation re-anchors to the diff row
+        // showing new-side line 3, and the cursor follows the same line.
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Diff);
+        assert_eq!(app.pending_anchor(0), Some((3, 3)));
+        assert_eq!(app.diff.cursor, 3);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_source_falls_back_to_a_placeholder_row() {
+        // working_dir points nowhere: the file can't be read, so the source
+        // view is a single placeholder row and annotating there is inert.
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: std::env::temp_dir()
+                .join("herdr-annotator-does-not-exist")
+                .to_string_lossy()
+                .into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert_eq!(app.view_row_count(), 1);
+        assert_eq!(app.source_line_count(), 0);
+        let lines = app.view_lines();
+        assert_eq!(lines.len(), 1);
+        let text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.starts_with("(no source view: "), "got {text:?}");
+
+        // `c` + Enter saves nothing: there are no source lines to anchor to.
+        app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE), size);
+        for ch in "nope".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE), size);
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+        assert!(app.pending.is_empty());
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -677,6 +677,26 @@ struct App<'a> {
     /// its source view is entered — diff and source rows can differ wildly
     /// in width, so one cap per file isn't enough once a second view exists.
     pan_limit: HashMap<(usize, ViewMode), usize>,
+    /// Each file's on-disk modification time when the review began,
+    /// captured in `new` right after `diff::load` produced the model. The
+    /// diff itself is a snapshot of that moment; source view instead reads
+    /// the worktree fresh the first time `t` is pressed, which can be much
+    /// later. If something touches the file in between, the two views
+    /// would silently show different revisions and a source-view
+    /// annotation's line numbers would no longer describe the diff the
+    /// agent receives — `ensure_source_loaded` checks the current mtime
+    /// against this baseline before trusting a lazy read. Absent entries
+    /// (the initial stat failed) mean there's nothing to compare against,
+    /// not that drift is impossible.
+    source_baseline_mtime: HashMap<usize, std::time::SystemTime>,
+}
+
+/// The file's current modification time, or `None` if it can't be stat'd
+/// (missing, permission error) — treated as "no signal" rather than an
+/// error, matching how deleted/unreadable files are already handled
+/// elsewhere in source view.
+fn file_mtime(working_dir: &str, path: &str) -> Option<std::time::SystemTime> {
+    std::fs::metadata(Path::new(working_dir).join(path)).ok()?.modified().ok()
 }
 
 /// One file's source view: its highlighted rows and how many lines it has
@@ -741,12 +761,16 @@ impl<'a> App<'a> {
     fn new(request: &'a ReviewRequest, model: &'a Result<DiffModel>) -> Self {
         let mut row_cache = HashMap::new();
         let mut pan_limit = HashMap::new();
+        let mut source_baseline_mtime = HashMap::new();
         if let Ok(m) = model {
             let hl = highlighter();
             for (i, file) in m.files.iter().enumerate() {
                 let rows = highlight_file_rows(hl, file);
                 pan_limit.insert((i, ViewMode::Diff), pan_cap_for_rows(&rows));
                 row_cache.insert(i, rows);
+                if let Some(mtime) = file_mtime(&request.working_dir, &file.path) {
+                    source_baseline_mtime.insert(i, mtime);
+                }
             }
         }
         App {
@@ -764,6 +788,7 @@ impl<'a> App<'a> {
             view: ViewMode::Diff,
             source_cache: HashMap::new(),
             pan_limit,
+            source_baseline_mtime,
         }
     }
 
@@ -880,6 +905,8 @@ impl<'a> App<'a> {
             Err("file deleted".to_string())
         } else if binary {
             Err("binary file".to_string())
+        } else if self.drifted(idx, &path) {
+            Err("file changed since the review started".to_string())
         } else {
             match load_source(&self.request.working_dir, &path) {
                 Ok(lines) => {
@@ -891,6 +918,17 @@ impl<'a> App<'a> {
             }
         };
         self.source_cache.insert(idx, entry);
+    }
+
+    /// Whether file `idx`'s on-disk mtime no longer matches the baseline
+    /// captured in `new` when the review began. `false` when there's no
+    /// baseline to compare against (the initial stat failed) — that's a
+    /// separate, unrelated failure mode, not evidence of drift.
+    fn drifted(&self, idx: usize, path: &str) -> bool {
+        match self.source_baseline_mtime.get(&idx) {
+            Some(&baseline) => file_mtime(&self.request.working_dir, path) != Some(baseline),
+            None => false,
+        }
     }
 
     /// After the navigator selection changes: reset the pane and, in source
@@ -4277,6 +4315,60 @@ mod tests {
         }
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
         assert!(app.pending.is_empty());
+    }
+
+    #[test]
+    fn source_view_refuses_a_file_that_changed_since_the_review_started() {
+        // Regression (Codex P1): the diff is a snapshot of the moment the
+        // review began, but source view reads the worktree fresh the first
+        // time `t` is pressed — which can be much later. If something
+        // touches the file in between, the two views could silently show
+        // different revisions, and a source-view annotation's line numbers
+        // would no longer describe the diff the agent receives.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-source-drift-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let full = dir.join("a.txt");
+        std::fs::write(&full, "original\n").expect("write source");
+
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let mut file = sample_file();
+        file.path = "a.txt".to_string();
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![file] });
+        // `App::new` stats the file NOW — this is the review-start baseline.
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+
+        // Simulate something touching the file after the review started:
+        // set its mtime an hour back, deterministically (no reliance on
+        // filesystem mtime resolution or wall-clock sleeps).
+        let file = std::fs::OpenOptions::new().write(true).open(&full).expect("reopen");
+        let drifted = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        file.set_modified(drifted).expect("backdate mtime");
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Source);
+        let text: String = app.view_lines()[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("changed"), "expected a drift placeholder, got {text:?}");
+
+        // An UNTOUCHED file still loads normally — this isn't refusing
+        // every file, only ones that actually drifted.
+        std::fs::write(dir.join("b.txt"), "steady\n").expect("write steady file");
+        let mut steady_file = sample_file();
+        steady_file.path = "b.txt".to_string();
+        let model2: Result<DiffModel> = Ok(DiffModel { files: vec![steady_file] });
+        let mut app2 = App::new(&request, &model2);
+        app2.focus = Focus::Diff;
+        app2.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert_eq!(app2.source_line_count(), 1, "an untouched file must still load");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -143,7 +143,7 @@ enum Focus {
 /// file's post-change source. Global rather than per-file — `t` switches the
 /// whole review's reading mode, and carrying it per file would make the same
 /// key mean different things on different rows of the navigator.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum ViewMode {
     Diff,
     Source,
@@ -670,12 +670,13 @@ struct App<'a> {
     /// be wasted I/O for a mode most reviews never enter, and `draw` borrows
     /// `App` immutably so it can never populate a cache itself.
     source_cache: HashMap<usize, Result<SourceFile, String>>,
-    /// Per file: the maximum horizontal pan (`pan_cap`'s value), precomputed
-    /// once from the widest row's pannable width minus just enough reserve —
-    /// the `‹` marker plus THAT row's own trailing glyph width — to keep its
-    /// final character reachable without over-reserving for a hypothetical
-    /// double-width glyph that isn't actually there.
-    pan_limit: HashMap<usize, usize>,
+    /// Per file, per view: the maximum horizontal pan (`pan_cap`'s value).
+    /// The diff-view cap is precomputed once in `App::new` from the diff
+    /// rows; the source-view cap is computed lazily in
+    /// `ensure_source_loaded`, from that file's source rows, the first time
+    /// its source view is entered — diff and source rows can differ wildly
+    /// in width, so one cap per file isn't enough once a second view exists.
+    pan_limit: HashMap<(usize, ViewMode), usize>,
 }
 
 /// One file's source view: its highlighted rows and how many lines it has
@@ -744,7 +745,7 @@ impl<'a> App<'a> {
             let hl = highlighter();
             for (i, file) in m.files.iter().enumerate() {
                 let rows = highlight_file_rows(hl, file);
-                pan_limit.insert(i, pan_cap_for_rows(&rows));
+                pan_limit.insert((i, ViewMode::Diff), pan_cap_for_rows(&rows));
                 row_cache.insert(i, rows);
             }
         }
@@ -881,10 +882,11 @@ impl<'a> App<'a> {
             Err("binary file".to_string())
         } else {
             match load_source(&self.request.working_dir, &path) {
-                Ok(lines) => Ok(SourceFile {
-                    lines: highlight_source_rows(highlighter(), &path, &lines),
-                    count: lines.len(),
-                }),
+                Ok(lines) => {
+                    let rows = highlight_source_rows(highlighter(), &path, &lines);
+                    self.pan_limit.insert((idx, ViewMode::Source), pan_cap_for_rows(&rows));
+                    Ok(SourceFile { lines: rows, count: lines.len() })
+                }
                 Err(err) => Err(err.root_cause().to_string()),
             }
         };
@@ -1144,10 +1146,14 @@ impl<'a> App<'a> {
         DispMap::new(ends)
     }
 
-    /// Largest useful horizontal pan for the selected file — see
-    /// `pan_cap_for_rows`, precomputed once per file in `App::new`.
+    /// Largest useful horizontal pan for the selected file IN THE CURRENT
+    /// VIEW — see `pan_cap_for_rows`. The diff-view cap is precomputed once
+    /// per file in `App::new`; the source-view cap is computed lazily in
+    /// `ensure_source_loaded` from that file's own (much wider or narrower)
+    /// source rows, since a diff row's width says nothing about a source
+    /// row's width.
     fn pan_cap(&self) -> usize {
-        self.pan_limit.get(&self.nav.selected).copied().unwrap_or(0)
+        self.pan_limit.get(&(self.nav.selected, self.view)).copied().unwrap_or(0)
     }
 
     /// The horizontal-pan offset a single rightward step should land on: a
@@ -3921,6 +3927,63 @@ mod tests {
         assert!(app.view == ViewMode::Diff);
         assert_eq!(app.pending_anchor(0), Some((3, 3)));
         assert_eq!(app.diff.cursor, 3);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn source_view_pan_cap_is_computed_from_source_rows_not_diff_rows() {
+        // The diff's widest row is a short one-liner (see `sample_file`), but
+        // the file on disk has a much longer line — a change elsewhere in
+        // the same file that never shows up in the diff's hunks. Source
+        // view's pan cap must reflect ITS OWN widest row, not the diff's.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-source-pan-cap-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("src")).expect("temp dir");
+        let long_line = "x".repeat(300);
+        std::fs::write(
+            dir.join("src/lib.rs"),
+            format!("fn main() {{\n    setup();\n    {long_line}\n}}\n"),
+        )
+        .expect("write source");
+
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+
+        // Diff view: the cap comes from the diff's own (short) rows,
+        // precomputed once in `App::new`.
+        let diff_cap = app.pan_cap();
+        let diff_rows = app.row_cache.get(&0).cloned().unwrap_or_default();
+        assert_eq!(diff_cap, pan_cap_for_rows(&diff_rows));
+
+        // `t`: load the source and compute ITS OWN cap, lazily.
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Source);
+        let source_rows = match app.source_cache.get(&0) {
+            Some(Ok(source)) => source.lines.clone(),
+            _ => panic!("expected the source to load"),
+        };
+        let source_cap = app.pan_cap();
+        assert_eq!(source_cap, pan_cap_for_rows(&source_rows));
+        assert!(
+            source_cap > diff_cap,
+            "the long line on disk must widen the source cap past the diff cap \
+             ({source_cap} vs {diff_cap})"
+        );
+
+        // Back to diff view: the ORIGINAL diff cap returns, not the source
+        // one left over from the view we just left.
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Diff);
+        assert_eq!(app.pan_cap(), diff_cap);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1180,19 +1180,29 @@ impl<'a> App<'a> {
 
     fn next_pan_stop(&self, current: usize, step: usize) -> usize {
         let target = current + step;
+        // The overshoot check must scan the rows actually ON SCREEN, not
+        // always the diff's: in source view those are wholly different rows
+        // (a source file's line widths have nothing to do with the diff's),
+        // so checking `row_cache` there would miss a short SOURCE row's
+        // overshoot entirely and jump the full step over it — the same bug
+        // `short_rows_stay_reachable_when_a_longer_row_sets_a_big_pan_cap`
+        // once pinned for diff rows, reappearing in the other view.
+        let rows: Option<&Vec<Line<'static>>> = match self.view {
+            ViewMode::Diff => self.row_cache.get(&self.nav.selected),
+            ViewMode::Source => self
+                .source_cache
+                .get(&self.nav.selected)
+                .and_then(|r| r.as_ref().ok())
+                .map(|s| &s.lines),
+        };
         // <= target, not < target: a row whose pannable width lands EXACTLY
         // on the step boundary is just as skipped-over as one strictly
         // inside it — landing there means every offset that would have
         // revealed that row's middle/tail (current+1..target-1) was never
         // visited, and `target` itself is already "fully panned off, empty"
         // for that row.
-        let overshoots_a_row = self
-            .row_cache
-            .get(&self.nav.selected)
-            .into_iter()
-            .flatten()
-            .map(pannable_cols)
-            .any(|cols| cols > current && cols <= target);
+        let overshoots_a_row =
+            rows.into_iter().flatten().map(pannable_cols).any(|cols| cols > current && cols <= target);
         if overshoots_a_row {
             current + 1
         } else {
@@ -2909,6 +2919,98 @@ mod tests {
             app.handle_key(right, term);
         }
         assert_eq!(app.diff.hscroll, app.pan_cap(), "must still reach the file-wide pan cap");
+    }
+
+    #[test]
+    fn source_view_short_rows_stay_reachable_when_a_longer_row_sets_a_big_pan_cap() {
+        // Regression (Codex P1): `next_pan_stop`'s overshoot check always
+        // scanned `row_cache` — the DIFF rows — even in source view. A
+        // source file's line widths have nothing to do with the diff's, so
+        // a short SOURCE row's overshoot went undetected there and Right
+        // jumped the full step straight past it: the same bug
+        // `short_rows_stay_reachable_when_a_longer_row_sets_a_big_pan_cap`
+        // pinned for diff rows, reappearing in the other view.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-source-pan-reach-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        // On disk: a short row and a much longer one — deliberately
+        // DIFFERENT from the diff's own (uniformly wide) lines below, so a
+        // next_pan_stop that (bugfully) checks diff rows instead sees no
+        // short row at all and never fine-steps.
+        std::fs::write(dir.join("a.txt"), format!("abcdef\n{}\n", "y".repeat(200)))
+            .expect("write source");
+
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let file = FileDiff {
+            path: "a.txt".to_string(),
+            old_path: None,
+            status: FileStatus::Added,
+            binary: false,
+            adds: 2,
+            dels: 0,
+            hunks: vec![Hunk {
+                // Wide even as the (unpinned, single-span) header row: every
+                // diff row here must be wide, or the header itself would be
+                // the "short row" that (correctly, by accident) triggers
+                // the overshoot check regardless of which rows are scanned.
+                header: "@".repeat(200),
+                old_start: 0,
+                old_count: 0,
+                new_start: 1,
+                new_count: 2,
+                // Uniformly wide diff rows: if next_pan_stop wrongly checks
+                // these instead of the source rows, it never detects an
+                // overshoot and always jumps the full step.
+                lines: vec![
+                    line(Origin::Add, None, Some(1), &"z".repeat(200)),
+                    line(Origin::Add, None, Some(2), &"z".repeat(200)),
+                ],
+            }],
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![file] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        // A WIDE pane, deliberately: a narrow one clamps `pan_step` itself
+        // down to single columns (see `pan_step`'s adaptive narrow-pane
+        // rule), which fine-steps regardless of the overshoot check and
+        // would mask this bug. Only a pane wide enough for the full
+        // `HSCROLL_STEP` makes the overshoot branch the thing deciding
+        // whether the short row is ever revealed.
+        let size = Size { width: 120, height: 40 };
+        app.handle_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE), size);
+        assert!(app.view == ViewMode::Source);
+        assert_eq!(app.pan_step(size), HSCROLL_STEP, "must be wide enough for a full step");
+        assert!(
+            app.pan_cap() > HSCROLL_STEP,
+            "the long source row must set a cap well past a single step"
+        );
+
+        let right = KeyEvent::new(KeyCode::Right, KeyModifiers::NONE);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..6 {
+            app.handle_key(right, size);
+            let source = match app.source_cache.get(&0) {
+                Some(Ok(source)) => source,
+                _ => panic!("expected the source to load"),
+            };
+            let mut row = source.lines[0].clone();
+            pan_and_clip(&mut row, app.diff.hscroll, 100, 2);
+            let tail: String = row.spans.iter().skip(2).map(|s| s.content.as_ref()).collect();
+            seen.extend(tail.chars());
+        }
+        for c in "cdef".chars() {
+            assert!(
+                seen.contains(&c),
+                "{c:?} never became visible while panning source view, saw {seen:?}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## What

User request: a toggle between the diff and a clean view of the new code, "much easier to review for example new files without the visual distractions".

- **`t`** toggles the diff pane to the file's post-change version read from the worktree (correct for any baseline — the worktree is the new side): full-file syntax highlighting, real line numbers, no `+`/`-` noise. Title shows ` [source]`; footer position becomes `path:line`.
- Cursor position **remaps across the toggle** both ways (diff row ↔ new-side line). Pan, wheel, click, drag, `b`, `z`, and all annotation keys work identically; `n`/`p` (hunk jump) is diff-only. Deleted/binary/unreadable files show a `(no source view: …)` placeholder.
- **Anchoring refactor** (the substantive part): annotations now anchor to their protocol line ranges as the source of truth; display rows are computed per view. An annotation made in source view renders correctly in diff view and vice versa. `PendingAnnotation` no longer stores view-specific rows.

**Stacked on #3** (which stacks on #2) — merge order: #2 → #3 → this. This diff shows only the toggle + refactor.

## How was it tested

- [x] `cargo test --locked` — 50 green. New: per-view anchor math (incl. out-of-hunk → hidden, old-side → remove row), cursor remap both directions, source span structure, and a temp-repo integration test: toggle → annotate source line → toggle back → same annotation re-anchored on the diff row
- [x] Build warning-free
- [ ] Live in herdr — reviewer: press `t` on a modified file and on an untracked file; leave a note in source view and toggle back

## Checklist

- [x] Build is warning-free
- [x] README keybinding updates follow in the release PR
- [x] No code copied from AGPL sources