### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-annotator"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-annotator"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "Herdr plugin: an agent-summoned, blocking diff-review pane with line annotations."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,7 +7,7 @@
 
 id = "jonasbaeumer.file-annotator"
 name = "File Annotator"
-version = "0.4.2"
+version = "0.5.0"
 min_herdr_version = "0.8.0"
 description = "Agent-summoned, blocking diff review: the agent calls an MCP tool, a review pane opens beside it, and the agent waits for your verdict and line annotations."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
## What

Version bump to 0.5.0 (Cargo.toml, herdr-plugin.toml, lockfile). After merging, the `v0.5.0` tag triggers the release workflow (the tag guard requires both manifests to match, hence this PR first).

Ships everything since 0.4.2 — the full UX round driven by live review feedback and ~50 Codex findings across PRs #2–#4 and #6:

- **Wide-code handling**: `←`/`→` horizontal pan with pinned gutter and `‹`/`…` clip markers, adaptive step in narrow panes, `b` navigator collapse, `z` pane zoom
- **Comment UX**: annot-style dashed editing box with `[ commit ⏎ ]` / `[ tag ^T ]` / `[ cancel esc ]` chips, tag-colored left-bar note chrome, display-column-correct wrapping everywhere
- **Source view**: `t` toggles a clean, fully-highlighted view of the post-change file; annotations anchor per view and work identically in both
- **Hardening**: UAX #29 grapheme-cluster atomicity for all pan/clip boundaries (CJK, combining marks, ZWJ emoji, flags, Indic conjuncts); symlink/size/mtime guards on source-view reads; u16 scroll clamps
- **Docs**: full keyboard+mouse Controls table, refreshed Status, comments cleaned of review-provenance narration

## How was it tested

- [x] `cargo test` — 82 green on the release commit
- [x] Build warning-free
- [x] Every feature e2e- or live-verified during its own PR cycle

## Checklist

- [x] Versions match across Cargo.toml and herdr-plugin.toml (tag guard requirement)