### PR TITLE
Guided review: non-blocking show_changes, agent navigation, deferred collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,24 @@ Optional `config.toml` in the plugin's config dir (find it with `herdr plugin co
 Long lines clip with `‹`/`…` markers; pan to see the rest. Annotations ride
 back to the agent on both `a` and `r` verdicts.
 
-## The `review_changes` tool
+## MCP tools
+
+Four tools, one shared review protocol. `review_changes` blocks the agent until
+a verdict lands. `show_changes` + `goto` + `collect_review` don't: they let the
+agent open the pane, narrate the diff in chat while pushing navigation, and
+come back for the verdict whenever it's ready. Annotations work exactly the
+same way in both modes, and the reviewer can also just finish the review in
+the pane at any time, without waiting to be asked.
+
+| Tool | Blocks? | Arguments | Returns |
+|------|---------|-----------|---------|
+| `review_changes` | Yes | `baseline?`, `note?`, `working_dir?` | Verdict + annotations (below), once the human decides. |
+| `show_changes` | No | `baseline?`, `note?`, `working_dir?` | `{"opened": true, "working_dir": "..."}` immediately. |
+| `goto` | No | `file` (repo-relative, new/post-change side), `line` (1-based) | Confirmation text; navigation is advisory. |
+| `collect_review` | No, polls | `wait_seconds?` (0–120, default 0) | Verdict + annotations once landed, else `{"status": "pending", "open_for_secs": N}`. |
+
+`baseline`, `note`, and `working_dir` mean the same thing for `review_changes`
+and `show_changes`:
 
 | Argument      | Type   | Meaning                                                            |
 |---------------|--------|--------------------------------------------------------------------|
@@ -110,7 +127,12 @@ back to the agent on both `a` and `r` verdicts.
 | `note`        | string | Message shown to the reviewer ("please check the retry logic").    |
 | `working_dir` | string | Repo to review. Defaults to the server's working directory.        |
 
-Result (JSON in the tool response):
+Only one review — blocking or guided — can be open at a time: `review_changes`
+and `show_changes` each refuse to start a second one, and `goto` / `collect_review`
+refuse to run without one already open.
+
+Verdict result (JSON in the tool response from `review_changes`, or from a
+`collect_review` call once a verdict has landed):
 
 ```json
 {
@@ -123,6 +145,29 @@ Result (JSON in the tool response):
   ]
 }
 ```
+
+`review_changes` blocks for as long as the config's `review_timeout` allows
+(unset = forever). The non-blocking tools have no such timeout — nothing is
+blocked, so there's nothing to time out; the review just stays open until the
+reviewer finishes in the pane or the agent calls `collect_review`.
+
+## Guided walkthroughs
+
+Use `show_changes` instead of `review_changes` when you want to talk the
+reviewer through a diff rather than hand it over cold and wait:
+
+1. **Open it, non-blocking.** `show_changes(working_dir=..., note="new retry
+   logic")` opens the review pane and returns immediately — you keep talking
+   in chat instead of freezing on a verdict.
+2. **Navigate while you explain.** Call `goto(file="src/retry.rs", line=42)`
+   as you describe each piece; the pane jumps to follow along. The reviewer
+   annotates as usual — annotations work exactly as they do in blocking mode.
+3. **Collect the verdict when you're ready.** `collect_review()` checks once;
+   pass `wait_seconds` to poll for a bit instead of hand-rolling a retry loop.
+   Nothing landed yet returns `{"status": "pending", ...}` — that's normal,
+   just call it again later. The reviewer can also finish in the pane on
+   their own schedule at any point; a pane closed without a decision surfaces
+   here as a normal `cancelled` verdict, not an error.
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ Verdict result (JSON in the tool response from `review_changes`, or from a
 
 `review_changes` blocks for as long as the config's `review_timeout` allows
 (unset = forever). The non-blocking tools have no such timeout — nothing is
-blocked, so there's nothing to time out; the review just stays open until the
-reviewer finishes in the pane or the agent calls `collect_review`.
+blocked, so there's nothing to time out; the review stays open until the
+reviewer finishes in the pane (or closes it). `collect_review` only ends the
+review when a verdict has actually landed — a `pending` result leaves the
+pane open, and the agent simply collects again later.
 
 ## Guided walkthroughs
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Verdict result (JSON in the tool response from `review_changes`, or from a
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "verdict": "request_changes",
   "summary": "retry loop still swallows the error",
   "annotations": [

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -266,11 +266,22 @@ fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Val
     if active.is_none() {
         return tool_error("no open review".to_string());
     }
-    let wait_seconds = args
-        .get("wait_seconds")
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
-        .min(120);
+    // Absent or explicit null means "use the documented default" (0, single
+    // check); anything else that isn't a 0..=120 integer is a malformed
+    // argument, not a value to silently coerce — matching goto's strict
+    // rejection of an invalid "line" rather than guessing at intent.
+    let wait_seconds = match args.get("wait_seconds") {
+        None | Some(Value::Null) => 0,
+        Some(v) => match v.as_u64() {
+            Some(n) if n <= 120 => n,
+            _ => {
+                return tool_error(
+                    "collect_review requires \"wait_seconds\" to be an integer between 0 and 120"
+                        .to_string(),
+                )
+            }
+        },
+    };
     let deadline = Instant::now() + Duration::from_secs(wait_seconds);
 
     loop {
@@ -508,6 +519,34 @@ mod tests {
         // Unblock and drain the fake pane so the test doesn't leak a thread.
         release_tx.send(()).unwrap();
         let _ = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        pane.join().unwrap();
+    }
+
+    #[test]
+    fn collect_review_rejects_a_malformed_wait_seconds_instead_of_coercing_it() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let mut active = Some(active_review);
+
+        // A negative value used to silently become 0 (single check, no
+        // error) via as_u64() failing and unwrap_or(0) swallowing that.
+        let negative = handle_collect_review(&json!({ "wait_seconds": -5 }), &mut active);
+        assert_eq!(negative["isError"], true);
+        assert!(active.is_some(), "a rejected argument must not disturb the open review");
+
+        // Above the documented 0..=120 range used to silently clamp to 120
+        // rather than telling the caller their argument was out of range.
+        let too_large = handle_collect_review(&json!({ "wait_seconds": 999 }), &mut active);
+        assert_eq!(too_large["isError"], true);
+
+        // A non-integer is just as malformed as a negative one.
+        let not_a_number = handle_collect_review(&json!({ "wait_seconds": "soon" }), &mut active);
+        assert_eq!(not_a_number["isError"], true);
+
+        // Omitted and explicit null are both legitimate ways to ask for the
+        // documented default (0, single check) and must not error.
+        release_tx.send(()).unwrap();
+        let omitted = handle_collect_review(&json!({}), &mut active);
+        assert_eq!(omitted["isError"], false);
         pane.join().unwrap();
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,32 +1,55 @@
-//! MCP stdio server exposing the `review_changes` tool.
+//! MCP stdio server exposing the review tools.
 //!
 //! Deliberately hand-rolled: the server speaks newline-delimited JSON-RPC 2.0 on
-//! stdin/stdout (the MCP stdio transport) and implements only what a single-tool
-//! server needs — initialize, tools/list, tools/call, ping. Logs go to stderr;
-//! stdout carries protocol frames only.
+//! stdin/stdout (the MCP stdio transport) and implements only what this server
+//! needs — initialize, tools/list, tools/call, ping. Logs go to stderr; stdout
+//! carries protocol frames only.
 //!
-//! `review_changes` is intentionally blocking: it binds a unix socket, asks herdr
-//! to open the review pane beside the agent, and does not return until the human
-//! delivers a verdict (or the pane dies, which maps to a Cancelled result). While
-//! a review is in flight no other frames are read — one review at a time is the
-//! product, not a limitation.
+//! Two review modes share one handoff socket setup (`prepare_handoff`):
+//!
+//! - `review_changes` is blocking: it opens the review pane and does not
+//!   return until the human delivers a verdict (or the pane dies, which maps
+//!   to a Cancelled result).
+//! - `show_changes` / `goto` / `collect_review` are the non-blocking
+//!   "guided review" trio: `show_changes` opens the pane and returns
+//!   immediately, `goto` pushes navigation to it while the agent narrates in
+//!   chat, and `collect_review` polls for the verdict whenever the agent is
+//!   ready to check.
+//!
+//! At most one review — blocking or non-blocking — is in flight at a time;
+//! that's tracked by the `active: Option<ActiveReview>` state threaded
+//! through the stdin loop.
 
 use std::io::{self, BufRead, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use serde_json::{json, Value};
 
 use crate::config::{self, Config};
 use crate::herdr;
-use crate::protocol::{Handoff, ReviewRequest, ReviewResult, PROTOCOL_VERSION};
+use crate::protocol::{GotoTarget, Handoff, OpenReview, ReviewRequest, ReviewResult, PROTOCOL_VERSION};
 
-const TOOL_NAME: &str = "review_changes";
+const REVIEW_CHANGES: &str = "review_changes";
+const SHOW_CHANGES: &str = "show_changes";
+const GOTO: &str = "goto";
+const COLLECT_REVIEW: &str = "collect_review";
+
+/// A non-blocking review in flight: the open handoff (write half for
+/// navigation, mailbox for the verdict), plus enough bookkeeping to answer
+/// `show_changes`'s own return value and `collect_review`'s pending status.
+struct ActiveReview {
+    open: OpenReview,
+    working_dir: String,
+    opened_at: Instant,
+}
 
 pub fn run() -> Result<()> {
     let config = config::load();
     let stdin = io::stdin().lock();
     let mut stdout = io::stdout().lock();
+    let mut active: Option<ActiveReview> = None;
     eprintln!("herdr-annotator mcp: ready (pid {})", std::process::id());
 
     for line in stdin.lines() {
@@ -49,9 +72,11 @@ pub fn run() -> Result<()> {
             ("initialize", Some(id)) => Some(result_frame(id, initialize_result(&params))),
             ("ping", Some(id)) => Some(result_frame(id, json!({}))),
             ("tools/list", Some(id)) => {
-                Some(result_frame(id, json!({ "tools": [tool_descriptor()] })))
+                Some(result_frame(id, json!({ "tools": tool_descriptors() })))
             }
-            ("tools/call", Some(id)) => Some(result_frame(id, handle_tool_call(&params, &config))),
+            ("tools/call", Some(id)) => {
+                Some(result_frame(id, handle_tool_call(&params, &config, &mut active)))
+            }
             (_, Some(id)) => Some(json!({
                 "jsonrpc": "2.0",
                 "id": id,
@@ -90,45 +115,190 @@ fn initialize_result(params: &Value) -> Value {
     })
 }
 
-fn tool_descriptor() -> Value {
+/// Input schema shared by `review_changes` and `show_changes`: they open the
+/// same kind of review, one blocking and one not.
+fn review_input_schema() -> Value {
     json!({
-        "name": TOOL_NAME,
-        "description": "Open a review pane beside this agent inside herdr and BLOCK until the human reviews the diff and returns a verdict with line-anchored annotations. Call this at checkpoints (e.g. before marking a task complete). The diff shown is the working tree vs `baseline` (a git rev); omit `baseline` to show all uncommitted changes.",
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "baseline": {
-                    "type": "string",
-                    "description": "Git rev to diff against (e.g. a commit hash captured before you started). Omit for all uncommitted changes vs HEAD."
-                },
-                "note": {
-                    "type": "string",
-                    "description": "Short message shown to the reviewer, e.g. what to focus on."
-                },
-                "working_dir": {
-                    "type": "string",
-                    "description": "Absolute path of the git repository to review. Defaults to the server's working directory."
-                }
+        "type": "object",
+        "properties": {
+            "baseline": {
+                "type": "string",
+                "description": "Git rev to diff against (e.g. a commit hash captured before you started). Omit for all uncommitted changes vs HEAD."
             },
-            "required": []
-        }
+            "note": {
+                "type": "string",
+                "description": "Short message shown to the reviewer, e.g. what to focus on."
+            },
+            "working_dir": {
+                "type": "string",
+                "description": "Absolute path of the git repository to review. Defaults to the server's working directory."
+            }
+        },
+        "required": []
     })
 }
 
-fn handle_tool_call(params: &Value, config: &Config) -> Value {
+fn tool_descriptors() -> Vec<Value> {
+    vec![
+        json!({
+            "name": REVIEW_CHANGES,
+            "description": "Open a review pane beside this agent inside herdr and BLOCK until the human reviews the diff and returns a verdict with line-anchored annotations. Call this at checkpoints (e.g. before marking a task complete). The diff shown is the working tree vs `baseline` (a git rev); omit `baseline` to show all uncommitted changes. The plugin's `review_timeout` config (if set) caps how long this call can block, returning a cancelled verdict past that point; unset means it blocks forever. Only one review may be open at a time: if a non-blocking review is already open (via show_changes), this fails — call collect_review first.",
+            "inputSchema": review_input_schema(),
+        }),
+        json!({
+            "name": SHOW_CHANGES,
+            "description": "Open a review pane beside this agent and return immediately — for a guided walkthrough where you explain the diff in chat while the human reads it at their own pace. Typical flow: call show_changes to open the pane, call goto once per point you want to highlight as you narrate it, then call collect_review to get the verdict and annotations once you're done (or whenever you want to check). Same arguments as review_changes: baseline, note, working_dir. Unlike review_changes this never blocks and has no timeout — nothing here is waiting on the human, so there's nothing to time out; the review stays open until the reviewer finishes in the pane or you call collect_review. Only one review may be open at a time: fails if one is already open.",
+            "inputSchema": review_input_schema(),
+        }),
+        json!({
+            "name": GOTO,
+            "description": "Push navigation to the review pane opened by show_changes, so it jumps to a file and line while you explain it in chat. Call this once per point you want the pane to follow, any time between show_changes and collect_review. `file` is a repo-relative path on the new (post-change) side; `line` is a 1-based line number on that side. Navigation is advisory: an unknown file or an out-of-range line is ignored (or clamped) by the pane, never an error here. Requires an open review — call show_changes first.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Repo-relative path, new/post-change side."
+                    },
+                    "line": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "1-based line number on the new side."
+                    }
+                },
+                "required": ["file", "line"]
+            },
+        }),
+        json!({
+            "name": COLLECT_REVIEW,
+            "description": "Check whether the reviewer has delivered a verdict in the review pane opened by show_changes. With `wait_seconds` omitted or 0 (the default), checks once and returns immediately. With `wait_seconds` > 0 (up to 120), polls for up to that long before giving up. While no verdict has landed yet this returns `{\"status\": \"pending\", \"open_for_secs\": N}` — that is not an error, just call collect_review again later. Once a verdict lands, this clears the open review and returns the same verdict+annotations JSON review_changes returns; annotations work exactly the same way in both modes. A pane the reviewer closed without deciding also surfaces here, as a normal cancelled verdict — not a failure. Requires an open review — call show_changes first.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "wait_seconds": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 120,
+                        "default": 0,
+                        "description": "How long to poll for a verdict before reporting pending. 0 = single check, no wait."
+                    }
+                },
+                "required": []
+            },
+        }),
+    ]
+}
+
+fn handle_tool_call(params: &Value, config: &Config, active: &mut Option<ActiveReview>) -> Value {
     let name = params.get("name").and_then(Value::as_str).unwrap_or_default();
-    if name != TOOL_NAME {
-        return tool_error(format!("unknown tool: {name}"));
-    }
     let args = params.get("arguments").cloned().unwrap_or(json!({}));
-    match run_review(&args, config) {
-        Ok(result) => {
-            let text = serde_json::to_string_pretty(&result)
-                .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+    match name {
+        REVIEW_CHANGES => handle_review_changes(&args, config, active),
+        SHOW_CHANGES => handle_show_changes(&args, config, active),
+        GOTO => handle_goto(&args, active),
+        COLLECT_REVIEW => handle_collect_review(&args, active),
+        other => tool_error(format!("unknown tool: {other}")),
+    }
+}
+
+fn handle_review_changes(args: &Value, config: &Config, active: &mut Option<ActiveReview>) -> Value {
+    if active.is_some() {
+        return tool_error("a non-blocking review is open — collect_review first".to_string());
+    }
+    match run_review(args, config) {
+        Ok(result) => review_result_response(&result),
+        Err(err) => tool_error(format!("{err:#}")),
+    }
+}
+
+fn handle_show_changes(args: &Value, config: &Config, active: &mut Option<ActiveReview>) -> Value {
+    if active.is_some() {
+        return tool_error(
+            "a review pane is already open — finish it there or call collect_review first".to_string(),
+        );
+    }
+    match run_show(args, config) {
+        Ok(new_active) => {
+            let text = serde_json::to_string_pretty(&json!({
+                "opened": true,
+                "working_dir": new_active.working_dir,
+            }))
+            .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+            *active = Some(new_active);
             json!({ "content": [{ "type": "text", "text": text }], "isError": false })
         }
         Err(err) => tool_error(format!("{err:#}")),
     }
+}
+
+fn handle_goto(args: &Value, active: &mut Option<ActiveReview>) -> Value {
+    let Some(active_review) = active.as_mut() else {
+        return tool_error("no open review — call show_changes first".to_string());
+    };
+
+    let file = match args.get("file").and_then(Value::as_str) {
+        Some(f) if !f.is_empty() => f.to_string(),
+        _ => return tool_error("goto requires a non-empty \"file\" argument".to_string()),
+    };
+    let line = match args
+        .get("line")
+        .and_then(Value::as_u64)
+        .and_then(|n| u32::try_from(n).ok())
+    {
+        Some(n) if n >= 1 => n,
+        _ => return tool_error("goto requires \"line\" to be an integer >= 1".to_string()),
+    };
+
+    match active_review.open.goto(&GotoTarget { file: file.clone(), line }) {
+        Ok(()) => {
+            let text = format!(
+                "navigated the review pane to {file}:{line} (advisory — if the pane doesn't recognize that file, it ignores the push)"
+            );
+            json!({ "content": [{ "type": "text", "text": text }], "isError": false })
+        }
+        Err(err) => tool_error(format!(
+            "could not push navigation ({err:#}) — the review pane may be gone; call collect_review to check for a verdict"
+        )),
+    }
+}
+
+fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Value {
+    if active.is_none() {
+        return tool_error("no open review".to_string());
+    }
+    let wait_seconds = args
+        .get("wait_seconds")
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(120);
+    let deadline = Instant::now() + Duration::from_secs(wait_seconds);
+
+    loop {
+        let taken = active.as_ref().and_then(|a| a.open.try_take());
+        if let Some(result) = taken {
+            *active = None;
+            return review_result_response(&result);
+        }
+        if wait_seconds == 0 || Instant::now() >= deadline {
+            let open_for_secs = active
+                .as_ref()
+                .map(|a| a.opened_at.elapsed().as_secs())
+                .unwrap_or(0);
+            let text = serde_json::to_string_pretty(&json!({
+                "status": "pending",
+                "open_for_secs": open_for_secs,
+            }))
+            .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+            return json!({ "content": [{ "type": "text", "text": text }], "isError": false });
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn review_result_response(result: &ReviewResult) -> Value {
+    let text = serde_json::to_string_pretty(result)
+        .unwrap_or_else(|e| format!("{{\"error\":\"serialize: {e}\"}}"));
+    json!({ "content": [{ "type": "text", "text": text }], "isError": false })
 }
 
 fn tool_error(message: String) -> Value {
@@ -136,9 +306,25 @@ fn tool_error(message: String) -> Value {
     json!({ "content": [{ "type": "text", "text": message }], "isError": true })
 }
 
-fn run_review(args: &Value, config: &Config) -> Result<ReviewResult> {
+/// Result of the setup shared by `review_changes` and `show_changes`: the
+/// handoff socket is bound, herdr has been asked to open the pane, and the
+/// pane has connected. From here the two tools diverge — one blocks on
+/// `Handoff::exchange`, the other calls `Handoff::open` and returns.
+struct PreparedHandoff {
+    handoff: Handoff,
+    request: ReviewRequest,
+    working_dir: String,
+}
+
+/// Shared setup for both review entry points: verify we're inside herdr,
+/// resolve the working dir, build the request, bind the handoff socket, ask
+/// herdr to open the pane, and wait for it to connect. The socket *file* is
+/// removed as soon as the connection attempt is settled (success or
+/// failure) — nothing past this point needs the filesystem path, only the
+/// accepted stream, and leaving it around leaks it into the temp dir.
+fn prepare_handoff(args: &Value, config: &Config) -> Result<PreparedHandoff> {
     if !herdr::inside_herdr() {
-        bail!("not running inside a herdr session (HERDR_ENV != 1); review_changes needs the agent to live in a herdr pane");
+        bail!("not running inside a herdr session (HERDR_ENV != 1); review tools need the agent to live in a herdr pane");
     }
     let working_dir = match args.get("working_dir").and_then(Value::as_str) {
         Some(dir) => dir.to_string(),
@@ -149,7 +335,7 @@ fn run_review(args: &Value, config: &Config) -> Result<ReviewResult> {
     };
     let request = ReviewRequest {
         version: PROTOCOL_VERSION,
-        working_dir,
+        working_dir: working_dir.clone(),
         baseline: args
             .get("baseline")
             .and_then(Value::as_str)
@@ -174,11 +360,144 @@ fn run_review(args: &Value, config: &Config) -> Result<ReviewResult> {
     let opened = herdr::open_review_pane(&socket_path.to_string_lossy(), config);
     let outcome = opened.and_then(|()| {
         let handoff = Handoff::accept(listener, config.accept_timeout)?;
-        eprintln!("herdr-annotator mcp: pane connected, waiting for verdict…");
-        handoff.exchange(&request, config.review_timeout)
+        eprintln!("herdr-annotator mcp: pane connected");
+        Ok(handoff)
     });
     let _ = std::fs::remove_file(&socket_path);
-    let result = outcome?;
+    let handoff = outcome?;
+
+    Ok(PreparedHandoff { handoff, request, working_dir })
+}
+
+fn run_review(args: &Value, config: &Config) -> Result<ReviewResult> {
+    let prepared = prepare_handoff(args, config)?;
+    eprintln!("herdr-annotator mcp: waiting for verdict…");
+    let result = prepared.handoff.exchange(&prepared.request, config.review_timeout)?;
     eprintln!("herdr-annotator mcp: verdict received: {:?}", result.verdict);
     Ok(result)
+}
+
+fn run_show(args: &Value, config: &Config) -> Result<ActiveReview> {
+    let prepared = prepare_handoff(args, config)?;
+    let open = prepared.handoff.open(&prepared.request)?;
+    eprintln!("herdr-annotator mcp: review pane open, returning control to the agent");
+    Ok(ActiveReview {
+        open,
+        working_dir: prepared.working_dir,
+        opened_at: Instant::now(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{Annotation, LineRange, PaneConnection, Side, Verdict};
+    use std::os::unix::net::UnixListener;
+
+    /// Stand up a fake pane on a unix socket (same pattern as protocol.rs's
+    /// tests) and hand back an `ActiveReview` wired to it, plus the pane's
+    /// thread handle and a sender the test uses to release the verdict on
+    /// its own schedule.
+    fn open_fake_review() -> (ActiveReview, std::thread::JoinHandle<()>, std::sync::mpsc::Sender<()>) {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!("annot-mcp-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join(format!("collect-{}.sock", COUNTER.fetch_add(1, Ordering::Relaxed)));
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _req = conn.receive_request().unwrap();
+            let (mut channel, _goto_rx) = conn.into_channel();
+            // Hold the verdict until the test has confirmed the pending state.
+            release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            channel
+                .send_result(&ReviewResult {
+                    version: PROTOCOL_VERSION,
+                    verdict: Verdict::Approve,
+                    summary: Some("looks good".into()),
+                    annotations: vec![Annotation {
+                        file: "src/lib.rs".into(),
+                        lines: LineRange { start: 1, end: 2 },
+                        side: Side::New,
+                        tag: None,
+                        comment: "nice".into(),
+                    }],
+                })
+                .unwrap();
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let request = ReviewRequest {
+            version: PROTOCOL_VERSION,
+            working_dir: "/tmp/repo".into(),
+            baseline: None,
+            note: None,
+        };
+        let open = handoff.open(&request).unwrap();
+        let _ = std::fs::remove_file(&sock);
+
+        (
+            ActiveReview { open, working_dir: "/tmp/repo".into(), opened_at: Instant::now() },
+            pane,
+            release_tx,
+        )
+    }
+
+    #[test]
+    fn collect_review_reports_pending_then_returns_the_verdict_and_clears_active() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let mut active = Some(active_review);
+
+        // Nothing sent yet: a single check (wait_seconds omitted) must report
+        // pending without blocking, and must not clear the active review.
+        let pending = handle_collect_review(&json!({}), &mut active);
+        assert_eq!(pending["isError"], false);
+        let pending_json: Value =
+            serde_json::from_str(pending["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(pending_json["status"], "pending");
+        assert!(active.is_some(), "a pending collect must not clear the active review");
+
+        // Let the fake pane deliver its verdict, then poll for it.
+        release_tx.send(()).unwrap();
+        let collected = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        assert_eq!(collected["isError"], false);
+        let result: ReviewResult =
+            serde_json::from_str(collected["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(result.verdict, Verdict::Approve);
+        assert_eq!(result.annotations.len(), 1);
+        assert!(active.is_none(), "collecting a verdict must clear the active review");
+
+        pane.join().unwrap();
+    }
+
+    #[test]
+    fn goto_and_collect_require_an_open_review() {
+        let mut active: Option<ActiveReview> = None;
+
+        let goto_err = handle_goto(&json!({ "file": "src/a.rs", "line": 1 }), &mut active);
+        assert_eq!(goto_err["isError"], true);
+        assert_eq!(goto_err["content"][0]["text"], "no open review — call show_changes first");
+
+        let collect_err = handle_collect_review(&json!({}), &mut active);
+        assert_eq!(collect_err["isError"], true);
+        assert_eq!(collect_err["content"][0]["text"], "no open review");
+    }
+
+    #[test]
+    fn goto_rejects_a_non_positive_line() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let mut active = Some(active_review);
+
+        let err = handle_goto(&json!({ "file": "src/a.rs", "line": 0 }), &mut active);
+        assert_eq!(err["isError"], true);
+
+        // Unblock and drain the fake pane so the test doesn't leak a thread.
+        release_tx.send(()).unwrap();
+        let _ = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        pane.join().unwrap();
+    }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -275,9 +275,19 @@ fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Val
 
     loop {
         let taken = active.as_ref().and_then(|a| a.open.try_take());
-        if let Some(result) = taken {
-            *active = None;
-            return review_result_response(&result);
+        match taken {
+            Some(Ok(result)) => {
+                *active = None;
+                return review_result_response(&result);
+            }
+            Some(Err(err)) => {
+                // A broken channel, not a verdict — clear the slot (there's
+                // nothing left to collect) and surface it as a real error
+                // rather than silently reporting a cancelled review.
+                *active = None;
+                return tool_error(format!("{err:#}"));
+            }
+            None => {}
         }
         if wait_seconds == 0 || Instant::now() >= deadline {
             let open_for_secs = active

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -176,11 +176,11 @@ fn tool_descriptors() -> Vec<Value> {
                 "type": "object",
                 "properties": {
                     "wait_seconds": {
-                        "type": "integer",
+                        "type": ["integer", "null"],
                         "minimum": 0,
                         "maximum": 120,
                         "default": 0,
-                        "description": "How long to poll for a verdict before reporting pending. 0 = single check, no wait."
+                        "description": "How long to poll for a verdict before reporting pending. 0 = single check, no wait. Omitted or null both mean the default — some MCP clients serialize omitted optionals as null."
                     }
                 },
                 "required": []

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -36,7 +36,13 @@ pub fn run() -> Result<()> {
         summary: outcome.summary,
         annotations: outcome.annotations,
     };
-    channel.send_result(&result)?;
+    // A failed send is expected on the disconnect path (the server already
+    // shut the socket — timeout or agent exit); the review is discarded, not
+    // a pane crash.
+    if let Err(err) = channel.send_result(&result) {
+        eprintln!("herdr-annotator pane: verdict could not be delivered (agent gone): {err:#}");
+        return Ok(());
+    }
     println!(
         "verdict sent: {}",
         serde_json::to_string(&result.verdict).unwrap_or_default()

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -23,9 +23,12 @@ pub fn run() -> Result<()> {
     };
     let mut conn = PaneConnection::connect(&socket_path)?;
     let request = conn.receive_request()?;
+    // Split the socket: verdict goes back on the write half; the read half
+    // becomes a live stream of agent-pushed navigation (guided walkthroughs).
+    let (mut channel, goto_rx) = conn.into_channel();
 
     let model = crate::diff::load(&request.working_dir, request.baseline.as_deref());
-    let outcome = crate::ui::run(&request, model)?;
+    let outcome = crate::ui::run(&request, model, goto_rx)?;
 
     let result = ReviewResult {
         version: PROTOCOL_VERSION,
@@ -33,7 +36,7 @@ pub fn run() -> Result<()> {
         summary: outcome.summary,
         annotations: outcome.annotations,
     };
-    conn.send_result(&result)?;
+    channel.send_result(&result)?;
     println!(
         "verdict sent: {}",
         serde_json::to_string(&result.verdict).unwrap_or_default()

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -191,17 +191,11 @@ impl Handoff {
 /// A review in flight: write half for navigation pushes, mailbox for the
 /// verdict. Dropping it abandons the review (the pane's eventual reply lands
 /// in the reader thread and is discarded).
-// TEMPORARY allow: `goto`/`try_take` are consumed by the MCP server's
-// non-blocking tools, the next commit on this branch — remove the allow there.
-#[allow(dead_code)]
 pub struct OpenReview {
     writer: UnixStream,
     result: std::sync::Arc<std::sync::Mutex<Option<ReviewResult>>>,
 }
 
-// TEMPORARY allow: see OpenReview — consumed by the MCP server's
-// non-blocking tools in the next commit on this branch.
-#[allow(dead_code)]
 impl OpenReview {
     /// Push navigation to the open pane (advisory; the pane clamps/ignores
     /// unknown targets).

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -211,6 +211,13 @@ impl OpenReview {
 
     /// Wait for the verdict, polling the mailbox. `None` waits forever; a
     /// lapsed deadline yields a `Cancelled` verdict ("review timed out").
+    ///
+    /// The background reader spawned by `open` owns the other half of this
+    /// socket and blocks in a read until the pane answers or the connection
+    /// closes. On a lapsed deadline nothing has told the pane the caller
+    /// gave up, so that read would otherwise block forever (and the pane
+    /// stays connected to a review nobody is waiting on) — shutting the
+    /// socket down here unblocks the reader with an EOF so it can exit.
     pub fn wait(&self, timeout: Option<Duration>) -> ReviewResult {
         let start = std::time::Instant::now();
         loop {
@@ -219,6 +226,7 @@ impl OpenReview {
             }
             if let Some(deadline) = timeout {
                 if start.elapsed() >= deadline {
+                    let _ = self.writer.shutdown(std::net::Shutdown::Both);
                     return ReviewResult::cancelled("review timed out");
                 }
             }
@@ -486,5 +494,53 @@ mod tests {
         // Don't join `pane` — it's asleep for several seconds and we don't
         // need it to finish to consider this test done.
         drop(pane);
+    }
+
+    #[test]
+    fn timeout_shuts_the_socket_down_so_the_pane_sees_it_close() {
+        use std::io::Read;
+
+        let dir = std::env::temp_dir().join(format!("annot-test-timeout-shutdown-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            // Connect and read the request, then hold the connection open
+            // without answering — the timeout is what has to close things,
+            // not the pane hanging up on its own.
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            // A bounded read timeout so an unfixed server (socket left
+            // open, reader thread blocked forever) fails this test instead
+            // of hanging it: the read should observe EOF well within this
+            // window once `wait` shuts the socket down on its own timeout.
+            conn.stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let mut buf = [0u8; 1];
+            conn.stream.read(&mut buf)
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let result = handoff
+            .exchange(
+                &ReviewRequest {
+                    version: PROTOCOL_VERSION,
+                    working_dir: "/".into(),
+                    baseline: None,
+                    note: None,
+                },
+                Some(Duration::from_millis(200)),
+            )
+            .unwrap();
+        assert_eq!(result.verdict, Verdict::Cancelled);
+
+        // The pane's read must observe EOF (0 bytes) once the caller's
+        // deadline passes, proving the server closed the socket rather than
+        // leaving the background reader (and this connection) hanging.
+        let n = pane.join().unwrap().unwrap();
+        assert_eq!(n, 0, "pane's read must see EOF once the timed-out review shuts the socket down");
+        let _ = std::fs::remove_file(&sock);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2,9 +2,13 @@
 //!
 //! Transport: one JSON object per line over a unix socket. The MCP server binds the
 //! socket, passes its path to the pane via the ANNOT_SOCKET env var at pane-open,
-//! sends a `ReviewRequest` line on accept, and blocks until the pane answers with a
-//! single `ReviewResult` line. EOF without a result means the pane died or the user
-//! closed it — the server maps that to `Verdict::Cancelled` instead of hanging.
+//! and sends tagged `ServerMsg` frames: first the `Request`, then any number of
+//! `Goto` navigation pushes while the human reviews (agent-guided walkthroughs).
+//! The pane answers with a single `ReviewResult` line whenever the reviewer
+//! decides; the server reads it on a mailbox thread, so callers choose blocking
+//! (`exchange`) or non-blocking (`open` + `try_take`) semantics. EOF without a
+//! result means the pane died or was closed — that maps to `Verdict::Cancelled`,
+//! never a hang.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -15,7 +19,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Env var carrying the handoff socket path into the pane process.
 pub const SOCKET_ENV: &str = "ANNOT_SOCKET";
@@ -31,6 +35,25 @@ pub struct ReviewRequest {
     /// Optional message from the agent to the reviewer ("please check the retry logic").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+}
+
+/// Server→pane messages. v2: the channel stays open after the initial
+/// request so the server can push navigation while the human reviews —
+/// the substrate for agent-guided walkthroughs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMsg {
+    Request(ReviewRequest),
+    Goto(GotoTarget),
+}
+
+/// A navigation push: focus this file at this NEW-side line (the post-change
+/// numbering annotations use). Unknown files or out-of-range lines are
+/// clamped or ignored by the pane, never an error — navigation is advisory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GotoTarget {
+    pub file: String,
+    pub line: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -132,34 +155,77 @@ impl Handoff {
         }
     }
 
-    /// Send the request, then block until the pane replies or hangs up.
+    /// Send the request and hand back an open channel: the caller can push
+    /// navigation to the pane and take the verdict whenever it lands. The
+    /// verdict is read on a mailbox thread so nothing here ever blocks.
+    pub fn open(mut self, request: &ReviewRequest) -> Result<OpenReview> {
+        write_json_line(&mut self.stream, &ServerMsg::Request(request.clone()))?;
+        let writer = self.stream.try_clone().context("splitting review socket")?;
+        let result = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let mailbox = std::sync::Arc::clone(&result);
+        let read_stream = self.stream;
+        std::thread::spawn(move || {
+            let mut reader = BufReader::new(read_stream);
+            let outcome = match read_json_line::<ReviewResult, _>(&mut reader) {
+                Ok(Some(result)) => result,
+                Ok(None) => ReviewResult::cancelled("review pane closed without a verdict"),
+                Err(_) => ReviewResult::cancelled("review channel failed"),
+            };
+            if let Ok(mut slot) = mailbox.lock() {
+                *slot = Some(outcome);
+            }
+        });
+        Ok(OpenReview { writer, result })
+    }
+
+    /// Blocking convenience: send the request and wait for the verdict.
     ///
-    /// `timeout`: `None` waits forever (the default); `Some(d)` sets a read
-    /// deadline, and a read that doesn't complete in time maps to a
-    /// `Cancelled` verdict rather than an error — a slow or silent reviewer
-    /// is not a protocol failure.
-    pub fn exchange(mut self, request: &ReviewRequest, timeout: Option<Duration>) -> Result<ReviewResult> {
-        write_json_line(&mut self.stream, request)?;
-        if let Some(timeout) = timeout {
-            self.stream
-                .set_read_timeout(Some(timeout))
-                .context("setting review read timeout")?;
-        }
-        let mut reader = BufReader::new(self.stream);
-        match read_json_line::<ReviewResult, _>(&mut reader) {
-            Ok(Some(result)) => Ok(result),
-            Ok(None) => Ok(ReviewResult::cancelled("review pane closed without a verdict")),
-            Err(err) => match err.downcast_ref::<std::io::Error>() {
-                Some(io_err)
-                    if matches!(
-                        io_err.kind(),
-                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
-                    ) =>
-                {
-                    Ok(ReviewResult::cancelled("review timed out"))
+    /// `timeout`: `None` waits forever (the default); a lapsed deadline maps
+    /// to a `Cancelled` verdict rather than an error — a slow or silent
+    /// reviewer is not a protocol failure.
+    pub fn exchange(self, request: &ReviewRequest, timeout: Option<Duration>) -> Result<ReviewResult> {
+        Ok(self.open(request)?.wait(timeout))
+    }
+}
+
+/// A review in flight: write half for navigation pushes, mailbox for the
+/// verdict. Dropping it abandons the review (the pane's eventual reply lands
+/// in the reader thread and is discarded).
+// TEMPORARY allow: `goto`/`try_take` are consumed by the MCP server's
+// non-blocking tools, the next commit on this branch — remove the allow there.
+#[allow(dead_code)]
+pub struct OpenReview {
+    writer: UnixStream,
+    result: std::sync::Arc<std::sync::Mutex<Option<ReviewResult>>>,
+}
+
+impl OpenReview {
+    /// Push navigation to the open pane (advisory; the pane clamps/ignores
+    /// unknown targets).
+    pub fn goto(&mut self, target: &GotoTarget) -> Result<()> {
+        write_json_line(&mut self.writer, &ServerMsg::Goto(target.clone()))
+            .context("pushing navigation to the review pane")
+    }
+
+    /// Take the verdict if the reviewer has delivered one.
+    pub fn try_take(&self) -> Option<ReviewResult> {
+        self.result.lock().ok().and_then(|mut slot| slot.take())
+    }
+
+    /// Wait for the verdict, polling the mailbox. `None` waits forever; a
+    /// lapsed deadline yields a `Cancelled` verdict ("review timed out").
+    pub fn wait(&self, timeout: Option<Duration>) -> ReviewResult {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(result) = self.try_take() {
+                return result;
+            }
+            if let Some(deadline) = timeout {
+                if start.elapsed() >= deadline {
+                    return ReviewResult::cancelled("review timed out");
                 }
-                _ => Err(err),
-            },
+            }
+            std::thread::sleep(Duration::from_millis(50));
         }
     }
 }
@@ -179,16 +245,45 @@ impl PaneConnection {
     }
 
     pub fn receive_request(&mut self) -> Result<ReviewRequest> {
-        match read_json_line::<ReviewRequest, _>(&mut self.reader)? {
-            Some(req) if req.version == PROTOCOL_VERSION => Ok(req),
-            Some(req) => bail!(
+        match read_json_line::<ServerMsg, _>(&mut self.reader)? {
+            Some(ServerMsg::Request(req)) if req.version == PROTOCOL_VERSION => Ok(req),
+            Some(ServerMsg::Request(req)) => bail!(
                 "protocol version mismatch: pane speaks v{PROTOCOL_VERSION}, server sent v{}",
                 req.version
             ),
+            Some(ServerMsg::Goto(_)) => bail!("protocol error: navigation before the review request"),
             None => bail!("server hung up before sending a review request"),
         }
     }
 
+    /// Split into a result-sender and a live stream of navigation pushes.
+    /// The buffered reader moves onto a thread (it may hold unconsumed
+    /// bytes, so it cannot be re-cloned); the thread exits on server EOF or
+    /// when the receiver is dropped.
+    pub fn into_channel(self) -> (PaneChannel, mpsc::Receiver<GotoTarget>) {
+        let (tx, rx) = mpsc::channel();
+        let mut reader = self.reader;
+        std::thread::spawn(move || loop {
+            match read_json_line::<ServerMsg, _>(&mut reader) {
+                Ok(Some(ServerMsg::Goto(target))) => {
+                    if tx.send(target).is_err() {
+                        break; // UI gone; nothing to navigate
+                    }
+                }
+                Ok(Some(ServerMsg::Request(_))) => {} // one request per session; ignore
+                Ok(None) | Err(_) => break,           // server hung up
+            }
+        });
+        (PaneChannel { stream: self.stream }, rx)
+    }
+}
+
+/// The pane's write half after `into_channel`: delivers the one verdict.
+pub struct PaneChannel {
+    stream: UnixStream,
+}
+
+impl PaneChannel {
     pub fn send_result(&mut self, result: &ReviewResult) -> Result<()> {
         write_json_line(&mut self.stream, result)
     }
@@ -212,7 +307,8 @@ mod tests {
             let mut conn = PaneConnection::connect(&sock_client).unwrap();
             let req = conn.receive_request().unwrap();
             assert_eq!(req.working_dir, "/tmp/repo");
-            conn.send_result(&ReviewResult {
+            let (mut channel, _goto_rx) = conn.into_channel();
+            channel.send_result(&ReviewResult {
                 version: PROTOCOL_VERSION,
                 verdict: Verdict::RequestChanges,
                 summary: Some("see comments".into()),
@@ -244,6 +340,83 @@ mod tests {
         assert_eq!(result.verdict, Verdict::RequestChanges);
         assert_eq!(result.annotations.len(), 1);
         assert_eq!(result.annotations[0].lines.start, 3);
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn goto_pushes_reach_the_pane_while_the_review_is_open() {
+        let dir = std::env::temp_dir().join(format!("annot-test-goto-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            let (mut channel, goto_rx) = conn.into_channel();
+            // Navigation arrives while the reviewer is "browsing".
+            let first = goto_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            assert_eq!((first.file.as_str(), first.line), ("src/a.rs", 10));
+            let second = goto_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            assert_eq!((second.file.as_str(), second.line), ("src/b.rs", 3));
+            channel
+                .send_result(&ReviewResult {
+                    version: PROTOCOL_VERSION,
+                    verdict: Verdict::Approve,
+                    summary: None,
+                    annotations: Vec::new(),
+                })
+                .unwrap();
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let mut open = handoff
+            .open(&ReviewRequest {
+                version: PROTOCOL_VERSION,
+                working_dir: "/tmp/repo".into(),
+                baseline: None,
+                note: None,
+            })
+            .unwrap();
+        // Nothing delivered yet: the mailbox is empty, not blocking.
+        assert!(open.try_take().is_none());
+        open.goto(&GotoTarget { file: "src/a.rs".into(), line: 10 }).unwrap();
+        open.goto(&GotoTarget { file: "src/b.rs".into(), line: 3 }).unwrap();
+        let result = open.wait(Some(Duration::from_secs(5)));
+        pane.join().unwrap();
+        assert_eq!(result.verdict, Verdict::Approve);
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn pane_rejects_a_mismatched_protocol_version() {
+        let dir = std::env::temp_dir().join(format!("annot-test-ver-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            conn.receive_request().unwrap_err()
+        });
+
+        let (mut stream, _) = listener.accept().unwrap();
+        write_json_line(
+            &mut stream,
+            &ServerMsg::Request(ReviewRequest {
+                version: 1, // stale server speaking the old revision
+                working_dir: "/tmp".into(),
+                baseline: None,
+                note: None,
+            }),
+        )
+        .unwrap();
+        let err = pane.join().unwrap();
+        assert!(err.to_string().contains("version mismatch"), "{err}");
         let _ = std::fs::remove_file(&sock);
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -158,6 +158,14 @@ impl Handoff {
     /// Send the request and hand back an open channel: the caller can push
     /// navigation to the pane and take the verdict whenever it lands. The
     /// verdict is read on a mailbox thread so nothing here ever blocks.
+    ///
+    /// EOF (the pane closed the connection without answering) is a genuine
+    /// `Cancelled` verdict — that's a normal way for a review to end. A
+    /// malformed line or any other read failure is a broken channel, not a
+    /// human decision, so it's kept out of the mailbox's `Cancelled`
+    /// vocabulary and surfaced as an `Err` instead — callers that treat
+    /// `Cancelled` as "nothing to worry about" must not see a protocol bug
+    /// dressed up as one.
     pub fn open(mut self, request: &ReviewRequest) -> Result<OpenReview> {
         write_json_line(&mut self.stream, &ServerMsg::Request(request.clone()))?;
         let writer = self.stream.try_clone().context("splitting review socket")?;
@@ -165,11 +173,13 @@ impl Handoff {
         let mailbox = std::sync::Arc::clone(&result);
         let read_stream = self.stream;
         std::thread::spawn(move || {
-            let mut reader = BufReader::new(read_stream);
-            let outcome = match read_json_line::<ReviewResult, _>(&mut reader) {
-                Ok(Some(result)) => result,
-                Ok(None) => ReviewResult::cancelled("review pane closed without a verdict"),
-                Err(_) => ReviewResult::cancelled("review channel failed"),
+            let outcome: std::result::Result<ReviewResult, String> = {
+                let mut reader = BufReader::new(read_stream);
+                match read_json_line::<ReviewResult, _>(&mut reader) {
+                    Ok(Some(result)) => Ok(result),
+                    Ok(None) => Ok(ReviewResult::cancelled("review pane closed without a verdict")),
+                    Err(err) => Err(format!("{err:#}")),
+                }
             };
             if let Ok(mut slot) = mailbox.lock() {
                 *slot = Some(outcome);
@@ -182,9 +192,10 @@ impl Handoff {
     ///
     /// `timeout`: `None` waits forever (the default); a lapsed deadline maps
     /// to a `Cancelled` verdict rather than an error — a slow or silent
-    /// reviewer is not a protocol failure.
+    /// reviewer is not a protocol failure. A broken channel (malformed
+    /// reply, read error) is a different thing and propagates as `Err`.
     pub fn exchange(self, request: &ReviewRequest, timeout: Option<Duration>) -> Result<ReviewResult> {
-        Ok(self.open(request)?.wait(timeout))
+        self.open(request)?.wait(timeout)
     }
 }
 
@@ -193,7 +204,7 @@ impl Handoff {
 /// in the reader thread and is discarded).
 pub struct OpenReview {
     writer: UnixStream,
-    result: std::sync::Arc<std::sync::Mutex<Option<ReviewResult>>>,
+    result: std::sync::Arc<std::sync::Mutex<Option<std::result::Result<ReviewResult, String>>>>,
 }
 
 impl OpenReview {
@@ -204,9 +215,16 @@ impl OpenReview {
             .context("pushing navigation to the review pane")
     }
 
-    /// Take the verdict if the reviewer has delivered one.
-    pub fn try_take(&self) -> Option<ReviewResult> {
-        self.result.lock().ok().and_then(|mut slot| slot.take())
+    /// Take the verdict if the reviewer has delivered one. `Err` means the
+    /// channel itself broke (malformed reply, read failure) — distinct from
+    /// a `Cancelled` verdict, which means the pane closed cleanly without
+    /// deciding.
+    pub fn try_take(&self) -> Option<Result<ReviewResult>> {
+        self.result
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
+            .map(|outcome| outcome.map_err(|msg| anyhow::anyhow!(msg)))
     }
 
     /// Wait for the verdict, polling the mailbox. `None` waits forever; a
@@ -218,7 +236,7 @@ impl OpenReview {
     /// gave up, so that read would otherwise block forever (and the pane
     /// stays connected to a review nobody is waiting on) — shutting the
     /// socket down here unblocks the reader with an EOF so it can exit.
-    pub fn wait(&self, timeout: Option<Duration>) -> ReviewResult {
+    pub fn wait(&self, timeout: Option<Duration>) -> Result<ReviewResult> {
         let start = std::time::Instant::now();
         loop {
             if let Some(result) = self.try_take() {
@@ -227,7 +245,7 @@ impl OpenReview {
             if let Some(deadline) = timeout {
                 if start.elapsed() >= deadline {
                     let _ = self.writer.shutdown(std::net::Shutdown::Both);
-                    return ReviewResult::cancelled("review timed out");
+                    return Ok(ReviewResult::cancelled("review timed out"));
                 }
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -389,7 +407,7 @@ mod tests {
         assert!(open.try_take().is_none());
         open.goto(&GotoTarget { file: "src/a.rs".into(), line: 10 }).unwrap();
         open.goto(&GotoTarget { file: "src/b.rs".into(), line: 3 }).unwrap();
-        let result = open.wait(Some(Duration::from_secs(5)));
+        let result = open.wait(Some(Duration::from_secs(5))).unwrap();
         pane.join().unwrap();
         assert_eq!(result.verdict, Verdict::Approve);
         let _ = std::fs::remove_file(&sock);
@@ -541,6 +559,41 @@ mod tests {
         // leaving the background reader (and this connection) hanging.
         let n = pane.join().unwrap().unwrap();
         assert_eq!(n, 0, "pane's read must see EOF once the timed-out review shuts the socket down");
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn a_malformed_reply_is_a_tool_error_not_a_cancelled_verdict() {
+        let dir = std::env::temp_dir().join(format!("annot-test-malformed-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            // A broken channel, not a human decision: reply with a line
+            // that isn't a valid ReviewResult at all.
+            conn.stream.write_all(b"not valid json\n").unwrap();
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let result = handoff.exchange(
+            &ReviewRequest {
+                version: PROTOCOL_VERSION,
+                working_dir: "/".into(),
+                baseline: None,
+                note: None,
+            },
+            None,
+        );
+        pane.join().unwrap();
+
+        // Must be a genuine Err, not an Ok(Cancelled) — a caller that
+        // treats Cancelled as "nothing to worry about" must see this.
+        assert!(result.is_err(), "a malformed reply must surface as an error, not {result:?}");
         let _ = std::fs::remove_file(&sock);
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -596,4 +596,23 @@ mod tests {
         assert!(result.is_err(), "a malformed reply must surface as an error, not {result:?}");
         let _ = std::fs::remove_file(&sock);
     }
+
+    #[test]
+    fn readme_example_verdict_matches_the_current_protocol_version() {
+        // README.md documents review_changes/collect_review's response shape
+        // with a literal example ReviewResult. It's prose, not code, so
+        // nothing else catches it drifting out of sync with a future
+        // PROTOCOL_VERSION bump the way this one did (the example was still
+        // showing v1 after the wire format moved to v2) — parse it for real
+        // and pin its version field to the constant.
+        let readme = include_str!("../README.md");
+        let start = readme.find("```json\n").expect("README's example verdict block") + "```json\n".len();
+        let end = start + readme[start..].find("```").expect("closing fence for the example block");
+        let example: ReviewResult = serde_json::from_str(readme[start..end].trim())
+            .expect("README's example verdict must itself be valid ReviewResult JSON");
+        assert_eq!(
+            example.version, PROTOCOL_VERSION,
+            "README's documented example verdict is stale — update it alongside any PROTOCOL_VERSION bump"
+        );
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -199,6 +199,9 @@ pub struct OpenReview {
     result: std::sync::Arc<std::sync::Mutex<Option<ReviewResult>>>,
 }
 
+// TEMPORARY allow: see OpenReview — consumed by the MCP server's
+// non-blocking tools in the next commit on this branch.
+#[allow(dead_code)]
 impl OpenReview {
     /// Push navigation to the open pane (advisory; the pane clamps/ignores
     /// unknown targets).

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,7 +36,7 @@ use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 use crate::diff::{load_source, DiffLine, DiffModel, FileDiff, FileStatus, Origin};
-use crate::protocol::{Annotation, LineRange, ReviewRequest, Side, Verdict};
+use crate::protocol::{Annotation, GotoTarget, LineRange, ReviewRequest, Side, Verdict};
 
 /// What the reviewer decided, handed back to `pane.rs`.
 pub struct Outcome {
@@ -84,7 +84,11 @@ fn syntax_for_path<'a>(hl: &'a Highlighter, path: &str) -> &'a SyntaxReference {
 ///
 /// `model` is the already-loaded diff (or the error from trying to load it —
 /// the UI still lets the reviewer cancel out even when the parser/git failed).
-pub fn run(request: &ReviewRequest, model: Result<DiffModel>) -> Result<Outcome> {
+pub fn run(
+    request: &ReviewRequest,
+    model: Result<DiffModel>,
+    goto_rx: std::sync::mpsc::Receiver<GotoTarget>,
+) -> Result<Outcome> {
     let _guard = TermGuard::enter()?;
     let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -92,6 +96,17 @@ pub fn run(request: &ReviewRequest, model: Result<DiffModel>) -> Result<Outcome>
 
     loop {
         terminal.draw(|frame| draw(frame, &app))?;
+        // Agent-pushed navigation (guided walkthroughs) arrives between
+        // keystrokes; drain it before waiting on input, and poll rather
+        // than block so pushes render within a tick even when the
+        // reviewer's hands are off the keyboard.
+        let size = terminal.size()?;
+        while let Ok(target) = goto_rx.try_recv() {
+            app.apply_goto(&target, size);
+        }
+        if !event::poll(std::time::Duration::from_millis(50))? {
+            continue;
+        }
         match event::read()? {
             Event::Key(key) if key.kind != KeyEventKind::Release => {
                 let size = terminal.size()?;
@@ -938,6 +953,45 @@ impl<'a> App<'a> {
         if self.view == ViewMode::Source {
             self.ensure_source_loaded();
         }
+    }
+
+    /// Agent-pushed navigation: focus `target.file` at new-side line
+    /// `target.line` in the CURRENT view. Advisory by contract — unknown
+    /// files are ignored, out-of-range lines clamp, and in diff view a line
+    /// outside the hunks lands on the nearest following changed/context row
+    /// (else the top). Never disturbs an open input bar.
+    fn apply_goto(&mut self, target: &GotoTarget, term_size: Size) {
+        if self.input.is_some() {
+            return;
+        }
+        let Ok(model) = self.model else { return };
+        let Some(idx) = model.files.iter().position(|f| f.path == target.file) else {
+            return;
+        };
+        if idx != self.nav.selected {
+            self.nav.selected = idx;
+            self.file_changed();
+        }
+        let row = match self.view {
+            ViewMode::Source => (target.line.saturating_sub(1) as usize)
+                .min(self.source_row_count().saturating_sub(1)),
+            ViewMode::Diff => {
+                let rows = self.diff_rows();
+                rows.iter()
+                    .position(
+                        |r| matches!(r, DiffRow::Line(l) if l.new_no == Some(target.line)),
+                    )
+                    .or_else(|| {
+                        rows.iter().position(
+                            |r| matches!(r, DiffRow::Line(l) if l.new_no.is_some_and(|n| n >= target.line)),
+                        )
+                    })
+                    .unwrap_or(0)
+            }
+        };
+        self.diff.cursor = row;
+        self.focus = Focus::Diff;
+        self.ensure_cursor_visible(term_size);
     }
 
     /// `t` in diff focus: switch views, carrying the cursor to the row

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -958,8 +958,9 @@ impl<'a> App<'a> {
     /// Agent-pushed navigation: focus `target.file` at new-side line
     /// `target.line` in the CURRENT view. Advisory by contract — unknown
     /// files are ignored, out-of-range lines clamp, and in diff view a line
-    /// outside the hunks lands on the nearest following changed/context row
-    /// (else the top). Never disturbs an open input bar.
+    /// outside the hunks lands on the nearest following changed/context row,
+    /// or the last new-side row if none follows (never wraps to the top).
+    /// Never disturbs an open input bar.
     fn apply_goto(&mut self, target: &GotoTarget, term_size: Size) {
         if self.input.is_some() {
             return;
@@ -985,6 +986,13 @@ impl<'a> App<'a> {
                         rows.iter().position(
                             |r| matches!(r, DiffRow::Line(l) if l.new_no.is_some_and(|n| n >= target.line)),
                         )
+                    })
+                    // Past the last new-side line: clamp to it, matching
+                    // source view's clamp-to-last-line rather than falling
+                    // through to row 0 (which would read as "jumped to the
+                    // top" for a target that was actually past the end).
+                    .or_else(|| {
+                        rows.iter().rposition(|r| matches!(r, DiffRow::Line(l) if l.new_no.is_some()))
                     })
                     .unwrap_or(0)
             }
@@ -2867,6 +2875,27 @@ mod tests {
         // No files: selection pinned to 0.
         nav.down(0);
         assert_eq!(nav.selected, 0);
+    }
+
+    #[test]
+    fn goto_targeting_a_line_past_the_diffs_end_clamps_instead_of_wrapping_to_the_top() {
+        // sample_file flattens to 8 rows (0..=7); row 7 carries the final
+        // new-side line, new_no 12.
+        let request = sample_request();
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        app.diff.cursor = 3; // away from both 0 and the target, so a
+                              // wrap-to-top bug is visible either way.
+
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 999 },
+            Size::new(80, 24),
+        );
+
+        assert_eq!(
+            app.diff.cursor, 7,
+            "a target past the last new-side line must clamp to it, not wrap to row 0"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -99,10 +99,18 @@ pub fn run(
         // Agent-pushed navigation (guided walkthroughs) arrives between
         // keystrokes; drain it before waiting on input, and poll rather
         // than block so pushes render within a tick even when the
-        // reviewer's hands are off the keyboard.
+        // reviewer's hands are off the keyboard. A disconnected channel
+        // means the server shut the socket (timeout, or the agent process
+        // exited): the verdict can no longer be delivered, so keeping the
+        // pane alive would let the reviewer finish a review into the void —
+        // exit as cancelled instead.
         let size = terminal.size()?;
-        while let Ok(target) = goto_rx.try_recv() {
-            app.apply_goto(&target, size);
+        if drain_navigation(&mut app, &goto_rx, size) {
+            return Ok(Outcome {
+                verdict: Verdict::Cancelled,
+                summary: Some("agent disconnected; the review could not be delivered".into()),
+                annotations: Vec::new(),
+            });
         }
         if !event::poll(std::time::Duration::from_millis(50))? {
             continue;
@@ -125,6 +133,24 @@ pub fn run(
             }
             // Release events, etc: just redraw next iteration.
             _ => {}
+        }
+    }
+}
+
+/// Apply all pending navigation pushes. Returns true when the channel is
+/// DISCONNECTED — the goto-reader thread ended because the server closed the
+/// socket — which the caller must treat as "this review can no longer be
+/// delivered", distinct from the ordinary empty-channel case.
+fn drain_navigation(
+    app: &mut App,
+    goto_rx: &std::sync::mpsc::Receiver<GotoTarget>,
+    size: Size,
+) -> bool {
+    loop {
+        match goto_rx.try_recv() {
+            Ok(target) => app.apply_goto(&target, size),
+            Err(std::sync::mpsc::TryRecvError::Empty) => return false,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => return true,
         }
     }
 }
@@ -2889,6 +2915,25 @@ mod tests {
         // No files: selection pinned to 0.
         nav.down(0);
         assert_eq!(nav.selected, 0);
+    }
+
+    #[test]
+    fn drain_distinguishes_disconnect_from_an_empty_channel() {
+        // An empty channel is the ordinary idle case; a DISCONNECTED one
+        // means the server shut the socket and the verdict can no longer be
+        // delivered — the pane must exit instead of reviewing into the void.
+        let request = sample_request();
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        let size = Size::new(80, 24);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        tx.send(GotoTarget { file: "src/lib.rs".into(), line: 12 }).unwrap();
+        assert!(!drain_navigation(&mut app, &rx, size), "live channel: not a disconnect");
+        assert_eq!(app.diff.cursor, 7, "the pending goto was applied while draining");
+
+        drop(tx);
+        assert!(drain_navigation(&mut app, &rx, size), "dropped sender must surface as disconnect");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -655,6 +655,13 @@ struct App<'a> {
     /// Some(mode) while the "request changes" summary prompt or the
     /// annotation comment prompt is open.
     input: Option<InputMode>,
+    /// The latest agent-pushed goto that arrived while an input bar was
+    /// open, held for replay once it closes. `apply_goto` never disturbs an
+    /// open input, but the target itself is still valid and shouldn't be
+    /// silently lost — only the latest matters, since an earlier one it
+    /// displaced was never shown either. Cleared (and applied) the moment
+    /// `input` goes back to `None`.
+    pending_goto: Option<GotoTarget>,
     /// Set by `v` in diff focus at the cursor row; the active selection is
     /// `min(anchor, cursor)..=max(anchor, cursor)` and grows/shrinks as the
     /// cursor moves. Diff-focus only; cleared by a second `v`, by `Esc`, or
@@ -795,6 +802,7 @@ impl<'a> App<'a> {
             nav: NavState::default(),
             diff: DiffViewState::default(),
             input: None,
+            pending_goto: None,
             visual_anchor: None,
             drag_origin: None,
             show_navigator: true,
@@ -960,9 +968,11 @@ impl<'a> App<'a> {
     /// files are ignored, out-of-range lines clamp, and in diff view a line
     /// outside the hunks lands on the nearest following changed/context row,
     /// or the last new-side row if none follows (never wraps to the top).
-    /// Never disturbs an open input bar.
+    /// Never disturbs an open input bar — while one is open the target is
+    /// held in `pending_goto` and replayed once it closes, rather than lost.
     fn apply_goto(&mut self, target: &GotoTarget, term_size: Size) {
         if self.input.is_some() {
+            self.pending_goto = Some(target.clone());
             return;
         }
         let Ok(model) = self.model else { return };
@@ -1156,6 +1166,10 @@ impl<'a> App<'a> {
             }
             if !close {
                 self.input = Some(mode);
+            } else if let Some(target) = self.pending_goto.take() {
+                // The input just closed: catch up to whatever navigation
+                // arrived (and was held) while the reviewer was typing.
+                self.apply_goto(&target, term_size);
             }
             // Typing can grow the editing box (more wrapped rows) or close
             // it back down to nothing — either way the set of display rows
@@ -2896,6 +2910,34 @@ mod tests {
             app.diff.cursor, 7,
             "a target past the last new-side line must clamp to it, not wrap to row 0"
         );
+    }
+
+    #[test]
+    fn a_goto_pushed_while_typing_is_replayed_once_the_input_bar_closes() {
+        let request = sample_request();
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        let size = Size::new(80, 24);
+        app.diff.cursor = 1;
+        // Reviewer is mid-comment: the input bar is open.
+        app.input = Some(InputMode::Summary { buf: String::new() });
+
+        // A goto arrives while typing — must not move the cursor or disturb
+        // the open input, but must not be lost either.
+        app.apply_goto(&GotoTarget { file: "src/lib.rs".into(), line: 12 }, size);
+        assert_eq!(app.diff.cursor, 1, "an open input bar must not be disturbed");
+        assert!(app.input.is_some(), "the input bar must stay open");
+        assert!(app.pending_goto.is_some(), "the target must be held, not dropped");
+
+        // Esc cancels the summary prompt and closes the input bar; the held
+        // goto should be applied as part of that close, not lost.
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), size);
+        assert!(app.input.is_none(), "Esc must close the input bar");
+        assert_eq!(
+            app.diff.cursor, 7,
+            "the deferred goto must be applied once the input bar closes"
+        );
+        assert!(app.pending_goto.is_none(), "the held target must be consumed, not replayed again");
     }
 
     #[test]

--- a/tests/e2e/guided_client.py
+++ b/tests/e2e/guided_client.py
@@ -32,6 +32,7 @@ harness failures. The server's stderr is inherited (passed through to our
 stderr) so protocol/debug logs are visible directly.
 """
 import json
+import select
 import subprocess
 import sys
 import time
@@ -48,12 +49,27 @@ def send(proc, obj):
 
 
 def read_response(proc, want_id, timeout):
-    """Block reading lines from proc.stdout until one has "id" == want_id."""
+    """Block reading lines from proc.stdout until one has "id" == want_id.
+
+    Unlike mcp_client.py's review_changes wait (which is meant to block for
+    however long a human review takes), every tool call here — show_changes,
+    goto, collect_review — is documented to return quickly, so a hang past
+    READ_TIMEOUT is a real bug, not a legitimate wait. A bare readline()
+    can't honor that: it blocks until the child writes something, so a
+    child that goes fully silent (crash, deadlock) never gives the deadline
+    check below a chance to run and this call — and the whole harness —
+    would hang past READ_TIMEOUT despite it. select() on the underlying fd
+    bounds each wait to the remaining budget so the deadline is always
+    re-checked, even against total silence.
+    """
     deadline = time.monotonic() + timeout
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise TimeoutError(f"no response with id={want_id} within {timeout}s")
+        ready, _, _ = select.select([proc.stdout], [], [], remaining)
+        if not ready:
+            continue  # remaining has elapsed; the deadline check above will fire
         line = proc.stdout.readline()
         if line == "":
             raise RuntimeError("server closed stdout before responding")

--- a/tests/e2e/guided_client.py
+++ b/tests/e2e/guided_client.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""End-to-end MCP stdio client for herdr-annotator's guided-review tools.
+
+Speaks the same newline-delimited JSON-RPC 2.0 stdio transport as
+mcp_client.py, but drives the non-blocking "guided review" flow instead of
+the blocking review_changes tool:
+
+    initialize -> initialized -> tools/call show_changes(...)
+
+show_changes returns immediately (it does not wait for a verdict), so from
+there this script reads commands from stdin, one per line, until EOF or a
+`quit` line:
+
+    goto <file> <line>   -> tools/call goto {file, line}
+    collect [seconds]    -> tools/call collect_review {wait_seconds: seconds or 0}
+    quit                 -> stop reading commands and exit
+
+Every tool result is printed to stdout as pretty JSON, preceded by a
+"### <tool>" header line, so a driving harness (or a human piping commands
+in) can tell the phases apart by scanning for the header.
+
+Usage:
+    guided_client.py <working_dir> [note]
+
+Then feed it commands on stdin, e.g.:
+    printf 'goto src/mcp.rs 10\ncollect 5\nquit\n' | guided_client.py /path/to/repo
+
+Exits 0 unless show_changes itself returned isError true. Later tool errors
+(a goto after the pane is gone, a still-pending collect) are printed but do
+not change the exit code — they are normal states in a guided review, not
+harness failures. The server's stderr is inherited (passed through to our
+stderr) so protocol/debug logs are visible directly.
+"""
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BINARY = Path(__file__).resolve().parent.parent.parent / "bin" / "herdr-annotator"
+READ_TIMEOUT = 120  # seconds to wait for any single tool call's response line
+
+
+def send(proc, obj):
+    line = json.dumps(obj)
+    proc.stdin.write(line + "\n")
+    proc.stdin.flush()
+
+
+def read_response(proc, want_id, timeout):
+    """Block reading lines from proc.stdout until one has "id" == want_id."""
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"no response with id={want_id} within {timeout}s")
+        line = proc.stdout.readline()
+        if line == "":
+            raise RuntimeError("server closed stdout before responding")
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") == want_id:
+            return msg
+
+
+def call_tool(proc, call_id, name, arguments):
+    """Send a tools/call, read its reply, print it under a "### <name>" header.
+
+    Returns the tool result dict (the "result" field of the JSON-RPC reply).
+    """
+    send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    )
+    response = read_response(proc, call_id, timeout=READ_TIMEOUT)
+    result = response.get("result", {})
+    print(f"### {name}")
+    print(json.dumps(result, indent=2))
+    sys.stdout.flush()
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: guided_client.py <working_dir> [note]", file=sys.stderr)
+        return 2
+    working_dir = sys.argv[1]
+    note = sys.argv[2] if len(sys.argv) > 2 else "guided e2e test"
+
+    proc = subprocess.Popen(
+        [str(BINARY), "mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=None,  # inherit: server stderr passes through to our stderr
+        text=True,
+        bufsize=1,  # line-buffered
+    )
+
+    call_id = 1
+    try:
+        send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": call_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "guided-e2e", "version": "0"},
+                },
+            },
+        )
+        read_response(proc, call_id, timeout=30)
+
+        send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+        call_id += 1
+        show_result = call_tool(
+            proc, call_id, "show_changes", {"working_dir": working_dir, "note": note}
+        )
+        if show_result.get("isError", True):
+            return 1
+
+        for raw_line in sys.stdin:
+            command = raw_line.strip()
+            if not command:
+                continue
+            parts = command.split()
+            verb = parts[0]
+
+            if verb == "quit":
+                break
+
+            if verb == "goto":
+                if len(parts) != 3:
+                    print(f"### goto\nusage: goto <file> <line>, got: {command!r}", file=sys.stderr)
+                    continue
+                file_arg, line_arg = parts[1], parts[2]
+                try:
+                    line_no = int(line_arg)
+                except ValueError:
+                    print(f"### goto\n\"line\" must be an integer, got {line_arg!r}", file=sys.stderr)
+                    continue
+                call_id += 1
+                call_tool(proc, call_id, "goto", {"file": file_arg, "line": line_no})
+                continue
+
+            if verb == "collect":
+                wait_seconds = 0
+                if len(parts) >= 2:
+                    try:
+                        wait_seconds = int(parts[1])
+                    except ValueError:
+                        print(
+                            f"### collect\n\"seconds\" must be an integer, got {parts[1]!r}",
+                            file=sys.stderr,
+                        )
+                        continue
+                call_id += 1
+                call_tool(proc, call_id, "collect_review", {"wait_seconds": wait_seconds})
+                continue
+
+            print(f"### {verb}\nunknown command: {command!r}", file=sys.stderr)
+
+        return 0
+    finally:
+        try:
+            proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/mcp_client.py
+++ b/tests/e2e/mcp_client.py
@@ -106,19 +106,24 @@ def main():
         )
         response = read_response(proc, 2, timeout=READ_TIMEOUT)
     finally:
+        # The server child must never outlive this harness: close its stdin,
+        # give it a moment to exit, then kill. A timeout or protocol error
+        # above used to propagate past a bare proc.wait(), orphaning the
+        # server (observed as inert `herdr-annotator mcp` processes piling
+        # up across interrupted test rounds).
         try:
             proc.stdin.close()
         except Exception:
             pass
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
 
     result = response.get("result", {})
     print(json.dumps(result, indent=2))
 
-    is_error = result.get("isError", True)
-
-    proc.wait(timeout=10)
-
-    return 1 if is_error else 0
+    return 1 if result.get("isError", True) else 0
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_read_timeout.py
+++ b/tests/e2e/test_read_timeout.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Regression check: guided_client.read_response's deadline must fire even
+when the child goes fully silent, not just when it answers with the wrong id.
+
+A bare readline() blocks forever on true silence, so the per-iteration
+deadline check inside read_response's loop never gets a chance to run —
+READ_TIMEOUT would be decorative for a genuinely hung MCP server (the actual
+failure mode this guards against). Not part of `cargo test` or CI; this
+harness has no automated runner (same as guided_client.py / mcp_client.py),
+so run it directly:
+
+    python3 tests/e2e/test_read_timeout.py
+"""
+import subprocess
+import sys
+import time
+
+from guided_client import read_response
+
+
+def main():
+    # A child that consumes one line (so our write doesn't fail) and then
+    # goes completely silent — never writes a byte back, unlike a child
+    # that merely answers with the wrong id.
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys, time; sys.stdin.readline(); time.sleep(120)"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        proc.stdin.write("go\n")
+        proc.stdin.flush()
+
+        start = time.monotonic()
+        try:
+            read_response(proc, want_id=1, timeout=1)
+        except TimeoutError:
+            elapsed = time.monotonic() - start
+        else:
+            print("FAIL: read_response returned instead of timing out", file=sys.stderr)
+            return 1
+
+        # Generous slack over the 1s deadline: proves the timeout fired near
+        # its bound (the fix), not merely "eventually" via some unrelated path.
+        if elapsed > 5:
+            print(f"FAIL: timeout took {elapsed:.1f}s to fire, wanted ~1s", file=sys.stderr)
+            return 1
+
+        print(f"OK: TimeoutError raised after {elapsed:.2f}s despite a fully silent child")
+        return 0
+    finally:
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

User request: review the diff while continuing to interact with the agent — e.g. have it explain and guide you through a large diff. Three new MCP tools on a v2 protocol:

- **`show_changes`** — opens the review pane and returns immediately; same args as `review_changes`. No timeout: nothing is blocked.
- **`goto {file, line}`** — pushes navigation to the open pane; as the agent explains hunk by hunk in chat, the pane follows. Advisory: unknown files ignored, lines clamped, never disturbs an open comment box.
- **`collect_review {wait_seconds?}`** — fetches the verdict + annotations when the reviewer finishes; returns `{"status":"pending"}` (not an error) until then.

Protocol v2 (version bumped per policy): server→pane frames become tagged `ServerMsg` (Request | Goto) on a channel held open for the review's lifetime; the verdict is read on a mailbox thread. Blocking `review_changes` is now a thin wrapper with identical semantics, and the two modes guard against each other. The pane's UI loop polls (50 ms) instead of blocking so pushed navigation renders between keystrokes.

## How was it tested

- [x] `cargo test` — 87 green (goto round-trip, version mismatch, pending→verdict collect against a scripted fake pane, UI goto mapping)
- [x] Build warning-free
- [x] One live smoke: `show_changes` → real pane opened non-blocking, `goto` navigated it, `collect_review` reported pending (disclosed: the pane briefly took focus in the dev workspace)
- [ ] Full live e2e (harness-driven goto/verdict/collect) — running next

## Checklist

- [x] PROTOCOL_VERSION bumped (1→2) for the wire-format change
- [x] README documents the tools and the guided-walkthrough flow
- [x] No new dependencies