### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-annotator"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-annotator"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 description = "Herdr plugin: an agent-summoned, blocking diff-review pane with line annotations."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,7 +7,7 @@
 
 id = "jonasbaeumer.file-annotator"
 name = "File Annotator"
-version = "0.5.0"
+version = "0.6.0"
 min_herdr_version = "0.8.0"
 description = "Agent-summoned, blocking diff review: the agent calls an MCP tool, a review pane opens beside it, and the agent waits for your verdict and line annotations."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
## What

Version bump to 0.6.0 (both manifests + lockfile); merging this lets the `v0.6.0` tag pass the release workflow's version guard.

Ships **guided review** (PR #8): the agent can now open the review pane without blocking, navigate it while explaining the diff in chat, and collect the verdict when the reviewer finishes.

- `show_changes` — opens the pane, returns immediately (no timeout: nothing is blocked)
- `goto {file, line}` — pushes navigation to the open pane; it follows the agent's narration
- `collect_review {wait_seconds?}` — `pending` until the verdict lands (not an error); annotations identical to blocking mode
- Protocol v2 (tagged server→pane frames on a held-open channel, mailbox verdict reads); blocking `review_changes` unchanged in behavior
- Hardening from the review loop: socket shutdown on timeout (no leaked threads/fds), protocol failures surface as errors rather than fake cancellations, disconnect-aware pane exit, goto clamping + deferred-while-typing semantics, e2e harness child-cleanup

## How was it tested

- [x] `cargo test` — 94 green on the release commit
- [x] Live e2e: non-blocking open (~1.5s), goto moved the real pane per push, pending→verdict collect, cancel-by-close
- [x] 6-round Codex loop, 10 findings fixed, all threads resolved

## Checklist

- [x] Versions match across Cargo.toml and herdr-plugin.toml (tag guard)