### PR TITLE
goto gains a view argument: steer the pane to diff or source view

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ the pane at any time, without waiting to be asked.
 |------|---------|-----------|---------|
 | `review_changes` | Yes | `baseline?`, `note?`, `working_dir?` | Verdict + annotations (below), once the human decides. |
 | `show_changes` | No | `baseline?`, `note?`, `working_dir?` | `{"opened": true, "working_dir": "..."}` immediately. |
-| `goto` | No | `file` (repo-relative, new/post-change side), `line` (1-based) | Confirmation text; navigation is advisory. |
+| `goto` | No | `file` (repo-relative, new/post-change side), `line` (1-based), `view` (optional: `diff` or `source`) | Confirmation text; navigation is advisory. |
 | `collect_review` | No, polls | `wait_seconds?` (0–120, default 0) | Verdict + annotations once landed, else `{"status": "pending", "open_for_secs": N}`. |
 
 `baseline`, `note`, and `working_dir` mean the same thing for `review_changes`

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -164,6 +164,11 @@ fn tool_descriptors() -> Vec<Value> {
                         "type": "integer",
                         "minimum": 1,
                         "description": "1-based line number on the new side."
+                    },
+                    "view": {
+                        "type": ["string", "null"],
+                        "enum": ["diff", "source", null],
+                        "description": "Optionally switch the pane's view before landing: \"diff\" (the changes) or \"source\" (the full post-change file — use when walking through whole files or lines outside the hunks). Omitted or null keeps the current view."
                     }
                 },
                 "required": ["file", "line"]
@@ -248,11 +253,23 @@ fn handle_goto(args: &Value, active: &mut Option<ActiveReview>) -> Value {
         Some(n) if n >= 1 => n,
         _ => return tool_error("goto requires \"line\" to be an integer >= 1".to_string()),
     };
+    // Same lenient-null / strict-otherwise contract as collect_review's
+    // wait_seconds: absent and null both mean "keep the current view".
+    let view = match args.get("view") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(v)) if v == "diff" || v == "source" => Some(v.clone()),
+        _ => {
+            return tool_error(
+                "goto requires \"view\" to be \"diff\" or \"source\" when given".to_string(),
+            )
+        }
+    };
 
-    match active_review.open.goto(&GotoTarget { file: file.clone(), line }) {
+    let view_note = view.as_deref().map(|v| format!(" in {v} view")).unwrap_or_default();
+    match active_review.open.goto(&GotoTarget { file: file.clone(), line, view }) {
         Ok(()) => {
             let text = format!(
-                "navigated the review pane to {file}:{line} (advisory — if the pane doesn't recognize that file, it ignores the push)"
+                "navigated the review pane to {file}:{line}{view_note} (advisory — if the pane doesn't recognize that file, it ignores the push)"
             );
             json!({ "content": [{ "type": "text", "text": text }], "isError": false })
         }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -54,6 +54,13 @@ pub enum ServerMsg {
 pub struct GotoTarget {
     pub file: String,
     pub line: u32,
+    /// Which view the pane should show the target in: "diff" or "source".
+    /// `None` keeps the pane's current view. Advisory like the rest of the
+    /// target — a file with no source side (deleted/binary) ignores a
+    /// source request. `#[serde(default)]` keeps the wire format compatible
+    /// with v2 peers that don't send it (per the protocol-change policy).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -405,8 +412,8 @@ mod tests {
             .unwrap();
         // Nothing delivered yet: the mailbox is empty, not blocking.
         assert!(open.try_take().is_none());
-        open.goto(&GotoTarget { file: "src/a.rs".into(), line: 10 }).unwrap();
-        open.goto(&GotoTarget { file: "src/b.rs".into(), line: 3 }).unwrap();
+        open.goto(&GotoTarget { file: "src/a.rs".into(), line: 10, view: None }).unwrap();
+        open.goto(&GotoTarget { file: "src/b.rs".into(), line: 3, view: None }).unwrap();
         let result = open.wait(Some(Duration::from_secs(5))).unwrap();
         pane.join().unwrap();
         assert_eq!(result.verdict, Verdict::Approve);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1023,12 +1023,22 @@ impl<'a> App<'a> {
                 self.visual_anchor = None;
                 self.diff.reset();
             }
-            Some("source") if self.view != ViewMode::Source => {
+            Some("source") => {
+                // The usability check must run for EVERY source request, not
+                // only when entering source view: a pane already in source
+                // mode steered to a deleted/binary/unreadable file would
+                // otherwise show the placeholder instead of keeping the
+                // useful diff, breaking the documented "ignored" contract.
+                let started_in_source = self.view == ViewMode::Source;
                 self.view = ViewMode::Source;
                 self.ensure_source_loaded();
                 if matches!(self.source_cache.get(&self.nav.selected), Some(Err(_))) {
                     self.view = ViewMode::Diff; // no usable source: request ignored
-                } else {
+                }
+                // Clear the selection only when the EFFECTIVE view changed
+                // relative to where this push started — that's when the row
+                // space under a live anchor shifts.
+                if started_in_source != (self.view == ViewMode::Source) {
                     self.visual_anchor = None;
                     self.diff.reset();
                 }
@@ -3000,7 +3010,9 @@ mod tests {
             baseline: None,
             note: None,
         };
-        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut ghost = sample_file();
+        ghost.path = "src/gone.rs".to_string(); // in the diff, never on disk
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file(), ghost] });
         let mut app = App::new(&request, &model);
         app.focus = Focus::Diff;
         let size = Size::new(120, 40);
@@ -3036,6 +3048,29 @@ mod tests {
         );
         assert!(app.visual_anchor.is_none(), "view switch must clear the visual anchor");
 
+        // The same contract while ALREADY in source view: enter source on a
+        // usable file, then steer to one whose source side never existed —
+        // the pane must fall back to diff, not show the placeholder, and the
+        // effective source→diff change clears a live selection.
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 2, view: Some("source".into()) },
+            size,
+        );
+        assert!(app.view == ViewMode::Source);
+        app.visual_anchor = Some(1);
+        app.apply_goto(
+            &GotoTarget { file: "src/gone.rs".into(), line: 2, view: Some("source".into()) },
+            size,
+        );
+        assert!(
+            app.view == ViewMode::Diff,
+            "already-in-source steering to an unusable file must fall back to diff"
+        );
+        assert!(
+            app.visual_anchor.is_none(),
+            "the effective source→diff change must clear the selection"
+        );
+
         // A source request for a file with no usable source is IGNORED —
         // the diff stays on screen, per the documented contract.
         app.apply_goto(
@@ -3052,6 +3087,7 @@ mod tests {
             app.view == ViewMode::Diff,
             "unusable source must keep the diff visible, not show a placeholder"
         );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1009,6 +1009,22 @@ impl<'a> App<'a> {
             self.nav.selected = idx;
             self.file_changed();
         }
+        // An explicit view request switches the pane before the line maps —
+        // advisory like everything else: an unknown view string is ignored,
+        // and a file with no usable source side simply renders the source
+        // placeholder (annotations stay inert there, as with manual `t`).
+        match target.view.as_deref() {
+            Some("diff") if self.view != ViewMode::Diff => {
+                self.view = ViewMode::Diff;
+                self.diff.reset();
+            }
+            Some("source") if self.view != ViewMode::Source => {
+                self.view = ViewMode::Source;
+                self.diff.reset();
+                self.ensure_source_loaded();
+            }
+            _ => {}
+        }
         let row = match self.view {
             ViewMode::Source => (target.line.saturating_sub(1) as usize)
                 .min(self.source_row_count().saturating_sub(1)),
@@ -2928,7 +2944,7 @@ mod tests {
         let size = Size::new(80, 24);
 
         let (tx, rx) = std::sync::mpsc::channel();
-        tx.send(GotoTarget { file: "src/lib.rs".into(), line: 12 }).unwrap();
+        tx.send(GotoTarget { file: "src/lib.rs".into(), line: 12, view: None }).unwrap();
         assert!(!drain_navigation(&mut app, &rx, size), "live channel: not a disconnect");
         assert_eq!(app.diff.cursor, 7, "the pending goto was applied while draining");
 
@@ -2947,7 +2963,7 @@ mod tests {
                               // wrap-to-top bug is visible either way.
 
         app.apply_goto(
-            &GotoTarget { file: "src/lib.rs".into(), line: 999 },
+            &GotoTarget { file: "src/lib.rs".into(), line: 999, view: None },
             Size::new(80, 24),
         );
 
@@ -2955,6 +2971,51 @@ mod tests {
             app.diff.cursor, 7,
             "a target past the last new-side line must clamp to it, not wrap to row 0"
         );
+    }
+
+    #[test]
+    fn goto_with_a_view_request_switches_the_pane_before_landing() {
+        // The agent can steer not just WHERE but HOW to look: view "source"
+        // shows the full post-change file (line maps directly), "diff" the
+        // hunks; omitted keeps the current view. Advisory like the rest.
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-goto-view-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("src")).expect("temp dir");
+        std::fs::write(dir.join("src/lib.rs"), "fn main() {\n    setup();\n    run();\n}\n")
+            .expect("write source");
+
+        let request = ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        };
+        let model: Result<DiffModel> = Ok(DiffModel { files: vec![sample_file()] });
+        let mut app = App::new(&request, &model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+        assert!(app.view == ViewMode::Diff);
+
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 2, view: Some("source".into()) },
+            size,
+        );
+        assert!(app.view == ViewMode::Source, "explicit source view request must switch");
+        assert_eq!(app.diff.cursor, 1, "source view maps line 2 to row index 1");
+
+        // Unknown view strings are ignored (advisory), current view kept.
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 1, view: Some("hexdump".into()) },
+            size,
+        );
+        assert!(app.view == ViewMode::Source);
+
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 12, view: Some("diff".into()) },
+            size,
+        );
+        assert!(app.view == ViewMode::Diff, "explicit diff view request must switch back");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -2969,7 +3030,7 @@ mod tests {
 
         // A goto arrives while typing — must not move the cursor or disturb
         // the open input, but must not be lost either.
-        app.apply_goto(&GotoTarget { file: "src/lib.rs".into(), line: 12 }, size);
+        app.apply_goto(&GotoTarget { file: "src/lib.rs".into(), line: 12, view: None }, size);
         assert_eq!(app.diff.cursor, 1, "an open input bar must not be disturbed");
         assert!(app.input.is_some(), "the input bar must stay open");
         assert!(app.pending_goto.is_some(), "the target must be held, not dropped");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1011,17 +1011,27 @@ impl<'a> App<'a> {
         }
         // An explicit view request switches the pane before the line maps —
         // advisory like everything else: an unknown view string is ignored,
-        // and a file with no usable source side simply renders the source
-        // placeholder (annotations stay inert there, as with manual `t`).
+        // and a source request for a file with no usable source side
+        // (deleted, binary, unreadable) is ignored too, keeping the useful
+        // diff on screen. Any actual switch clears a live visual selection:
+        // its anchor indexes the OLD view's row space, and combining it with
+        // a new-space cursor would let `c` save an unrelated line range
+        // (same rule as the manual `t` toggle).
         match target.view.as_deref() {
             Some("diff") if self.view != ViewMode::Diff => {
                 self.view = ViewMode::Diff;
+                self.visual_anchor = None;
                 self.diff.reset();
             }
             Some("source") if self.view != ViewMode::Source => {
                 self.view = ViewMode::Source;
-                self.diff.reset();
                 self.ensure_source_loaded();
+                if matches!(self.source_cache.get(&self.nav.selected), Some(Err(_))) {
+                    self.view = ViewMode::Diff; // no usable source: request ignored
+                } else {
+                    self.visual_anchor = None;
+                    self.diff.reset();
+                }
             }
             _ => {}
         }
@@ -3015,6 +3025,33 @@ mod tests {
             size,
         );
         assert!(app.view == ViewMode::Diff, "explicit diff view request must switch back");
+
+        // A live `v` selection must not survive an agent-pushed view switch:
+        // its anchor indexes the old view's rows, and `c` would otherwise
+        // save an unrelated range (same rule as the manual toggle).
+        app.visual_anchor = Some(3);
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 2, view: Some("source".into()) },
+            size,
+        );
+        assert!(app.visual_anchor.is_none(), "view switch must clear the visual anchor");
+
+        // A source request for a file with no usable source is IGNORED —
+        // the diff stays on screen, per the documented contract.
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 12, view: Some("diff".into()) },
+            size,
+        );
+        std::fs::remove_file(dir.join("src/lib.rs")).expect("delete source");
+        app.source_cache.clear(); // force a fresh load attempt
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 2, view: Some("source".into()) },
+            size,
+        );
+        assert!(
+            app.view == ViewMode::Diff,
+            "unusable source must keep the diff visible, not show a placeholder"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## What

During the live guided-review demo, switching the pane to the full-file source view required reaching around the MCP surface (injecting the `t` key via herdr's CLI) — a side channel only a local agent could use. `goto` now carries an optional `view` argument:

- `"source"` — full post-change file (line numbers map directly); use for walking through whole files or lines outside the hunks
- `"diff"` — back to the changes
- omitted / null — keep the current view

Carried as an optional `GotoTarget.view` field, `#[serde(default)]` so the v2 wire format stays compatible (no version bump needed per the protocol policy). Advisory semantics preserved: unknown view strings are ignored; deleted/binary files render the source placeholder.

## How was it tested

- [x] `cargo test` — 95 green (new test: switch to source with direct line mapping, unknown-view ignore, switch back to diff)
- [x] Build warning-free (`--all-targets`)
- [x] Schema follows the established null-tolerance contract (`type: ["string","null"]` + enum)

## Checklist

- [x] README tool table updated
- [x] Wire-compatible: no PROTOCOL_VERSION bump required (optional field, serde default)