### PR TITLE
Release 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-annotator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-annotator"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT"
 description = "Herdr plugin: an agent-summoned, blocking diff-review pane with line annotations."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,7 +7,7 @@
 
 id = "jonasbaeumer.file-annotator"
 name = "File Annotator"
-version = "0.6.0"
+version = "0.6.1"
 min_herdr_version = "0.8.0"
 description = "Agent-summoned, blocking diff review: the agent calls an MCP tool, a review pane opens beside it, and the agent waits for your verdict and line annotations."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
## What

Version bump to 0.6.1; merging lets the `v0.6.1` tag pass the release workflow's version guard. Ships both of today's live-feedback improvements:

- **`goto` view steering** (#10): the guided-walkthrough `goto` tool gains an optional `view` argument (`"diff"` | `"source"`) — the agent can steer not just where but how to look, entirely through MCP. Wire-compatible with v2 (optional field). Selection-safety on pushed switches; unusable-source requests keep the diff visible per contract.
- **`?` help overlay + slim footer** (#11): a centered, scrollable, context-aware key reference openable from anywhere (`q` inside closes the overlay, never the review); the footer shrinks to position + verdict keys + `? help`, ending the right-edge hint overflow.

## How was it tested

- [x] `cargo test` — 102 green on the release commit (union of both PRs' suites)
- [x] Both PRs individually Codex-reviewed to convergence; overlay previewed live in a real pane
- [x] Build warning-free

## Checklist

- [x] Versions match across Cargo.toml and herdr-plugin.toml (tag guard)
