### PR TITLE
README: pitch-first restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,57 @@
 # herdr-file-annotator
 
-Agent-summoned, **blocking** diff review inside [herdr](https://herdr.dev).
-
-Your coding agent reaches a checkpoint and calls one MCP tool — `review_changes`.
-A review pane opens beside it in your herdr workspace showing only what changed.
-The agent is **frozen** until you scroll the diff, leave feedback, and pick a
-verdict. The tool call then returns your review as structured JSON the agent can
-act on.
+**Code review for AI agents, inside your terminal.** The agent stops and asks
+*you* — in a real review pane, on real diffs, with feedback it can act on.
 
 ![Demo: the agent opens a review pane, walks through the diff while the pane follows, and collects two line-anchored annotations](docs/demo.gif)
 
-This is the inverse of [herdr-reviewr](https://github.com/persiyanov/herdr-reviewr)
-(human-initiated, agent keeps running); both can coexist. The interaction model
-is inspired by [annot](https://github.com/denolehov/annot), rebuilt as a native
-herdr citizen.
+Your coding agent reaches a checkpoint and calls one MCP tool. A review pane
+opens beside it in your [herdr](https://herdr.dev) workspace showing only what
+changed. You scroll, annotate lines, pick a verdict — and your review flows
+back to the agent as structured JSON it acts on. No context switch, no
+copy-pasting feedback into chat, no rubber-stamping.
+
+## Core features
+
+- **A real sign-off gate** — `review_changes` *freezes* the agent until you
+  approve, request changes, or cancel. The agent cannot run past your review.
+- **Guided walkthroughs** — or flip it: the agent opens the pane without
+  blocking, explains the diff in chat while the pane follows its pointer
+  (`show_changes` + `goto`), and collects your verdict when you're done.
+- **Line-anchored annotations** — select a range, comment, tag it
+  (`fix` / `verify` / `question` / `nit`). Notes render inline under the code
+  and return to the agent with exact file/line anchors.
+- **A reviewer's editor, not a toy pane** — syntax-highlighted diffs, a
+  diff ↔ full-source toggle, full mouse support, horizontal panning for wide
+  code, a `?` key-reference overlay, and Unicode-correct rendering down to
+  emoji and Indic conjuncts.
+- **Never wedges your agent** — closed panes, timeouts, and disconnects all
+  resolve to a clean `cancelled` verdict, never a hang.
+- **One-command install** — prebuilt, SHA-256-verified binaries for macOS and
+  Linux; listed on the herdr marketplace.
+
+## Quick start
+
+Requires herdr ≥ 0.8.0.
+
+```sh
+# 1. Install the plugin
+herdr plugin install JonasBaeumer/herdr-file-annotator
+
+# 2. Register the MCP server with your agent (Claude Code shown) —
+#    find <plugin_root> via: herdr plugin list --plugin jonasbaeumer.file-annotator --json
+claude mcp add annotator -- "<plugin_root>/bin/herdr-annotator" mcp
+```
+
+Then tell the agent when to ask for review — e.g. in `CLAUDE.md`:
+
+> Before marking any task complete, call the `review_changes` tool and act on
+> the returned annotations. Do not proceed on a `request_changes` or `reject`
+> verdict without addressing the feedback.
+
+That's the whole setup. Everything below is reference.
+
+---
 
 ## How it works
 
@@ -38,58 +76,11 @@ One Rust binary, two modes:
 - `herdr-annotator pane` — the review TUI, declared as a herdr plugin pane
   entrypoint. Launched by herdr, never by hand.
 
-## Install
-
-Requires herdr ≥ 0.8.0.
-
-```sh
-herdr plugin install JonasBaeumer/herdr-file-annotator
-```
-
-Downloads a prebuilt binary for macOS (arm64/x86_64) and Linux (x86_64/arm64, static musl)
-matching the release, verifies its SHA-256, and falls back to building from source with cargo
-if no matching prebuilt exists.
-
-Then register the MCP server with your agent (Claude Code shown). `herdr plugin install`
-places the plugin under a herdr-managed directory (e.g.
-`~/.config/herdr/plugins/github/herdr-file-annotator-<hash>`) rather than your working
-directory, so look it up with `herdr plugin list` (or `herdr plugin list --plugin
-jonasbaeumer.file-annotator --json` for the exact `plugin_root` field), then:
-
-```sh
-claude mcp add annotator -- "<plugin_root>/bin/herdr-annotator" mcp
-```
-
-Finally, tell the agent when to ask for review — e.g. in `CLAUDE.md`:
-
-> Before marking any task complete, call the `review_changes` tool and act on
-> the returned annotations. Do not proceed on a `request_changes` or `reject`
-> verdict without addressing the feedback.
-
-## Install (local development)
-
-Requires a Rust toolchain and herdr ≥ 0.8.0.
-
-```sh
-git clone https://github.com/JonasBaeumer/herdr-file-annotator
-cd herdr-file-annotator
-./scripts/dev-link.sh          # builds, symlinks bin/, runs `herdr plugin link`
-```
-
-`herdr plugin link` skips the `[[build]]` step (`scripts/fetch-or-build.sh`), so
-`dev-link.sh`'s own `cargo build` is what produces `bin/herdr-annotator` here.
-
-## Configuration
-
-Optional `config.toml` in the plugin's config dir (find it with `herdr plugin config-dir jonasbaeumer.file-annotator`):
-
-| Key | Default | Meaning |
-|-----|---------|---------|
-| `placement` | `"split"` | `split` (beside the agent) or `tab` |
-| `direction` | `"right"` | Split direction: `right` or `down` |
-| `focus` | `true` | Move keyboard focus to the review pane when it opens |
-| `accept_timeout_secs` | `20` | How long the agent waits for the pane to appear |
-| `review_timeout_secs` | unset | If set, a review left open this long returns a `cancelled` verdict |
+The plugin installs under a herdr-managed directory (e.g.
+`~/.config/herdr/plugins/github/herdr-file-annotator-<hash>`); installs
+download a prebuilt binary for macOS (arm64/x86_64) or Linux (x86_64/arm64,
+static musl), verify its SHA-256, and fall back to building from source with
+cargo if no matching prebuilt exists.
 
 ## Controls
 
@@ -175,13 +166,46 @@ reviewer through a diff rather than hand it over cold and wait:
    their own schedule at any point; a pane closed without a decision surfaces
    here as a normal `cancelled` verdict, not an error.
 
+## Configuration
+
+Optional `config.toml` in the plugin's config dir (find it with `herdr plugin config-dir jonasbaeumer.file-annotator`):
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `placement` | `"split"` | `split` (beside the agent) or `tab` |
+| `direction` | `"right"` | Split direction: `right` or `down` |
+| `focus` | `true` | Move keyboard focus to the review pane when it opens |
+| `accept_timeout_secs` | `20` | How long the agent waits for the pane to appear |
+| `review_timeout_secs` | unset | If set, a review left open this long returns a `cancelled` verdict |
+
+## Development
+
+Requires a Rust toolchain and herdr ≥ 0.8.0.
+
+```sh
+git clone https://github.com/JonasBaeumer/herdr-file-annotator
+cd herdr-file-annotator
+./scripts/dev-link.sh          # builds, symlinks bin/, runs `herdr plugin link`
+```
+
+`herdr plugin link` skips the `[[build]]` step (`scripts/fetch-or-build.sh`), so
+`dev-link.sh`'s own `cargo build` is what produces `bin/herdr-annotator` here.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the fork-and-PR workflow.
+
+## Related projects
+
+This is the inverse of [herdr-reviewr](https://github.com/persiyanov/herdr-reviewr)
+(human-initiated, agent keeps running); both can coexist. The interaction model
+is inspired by [annot](https://github.com/denolehov/annot), rebuilt as a native
+herdr citizen.
+
 ## Status
 
 Released and feature-complete for the core loop: agent-summoned blocking
-review, two-pane syntax-highlighted diff viewer with full mouse support,
-line-anchored annotations (range select, tags, inline comments), a config
-file, and prebuilt, checksum-verified binaries for macOS and Linux via
-`herdr plugin install`. Listed on the herdr marketplace.
+review, guided walkthroughs, two-pane syntax-highlighted diff viewer with
+full mouse support, line-anchored annotations, a config file, and prebuilt,
+checksum-verified binaries for macOS and Linux. Listed on the herdr
+marketplace.
 
 See the [releases](https://github.com/JonasBaeumer/herdr-file-annotator/releases)
 for per-version changes; ongoing work happens in pull requests.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
 # herdr-file-annotator
 
-**Maximize agentic development — without losing touch with the actual codebase.**
+**Maximize agentic development but dont lose touch with the actual codebase.**
 
 Working with coding agents usually forces a choice: adopt an IDE-style tool
 and leave your terminal workflow behind, or stay in the terminal and squint
 at raw diffs and verbose agent prose in chat. This [herdr](https://herdr.dev)
-plugin removes the choice — when you and your agent need to meet over actual
+plugin removes the choice, when you and your agent need to meet over actual
 code, a review pane opens right in your workspace, and closes when you're
 done.
 
 ![Demo: the agent opens a review pane, walks through the diff while the pane follows, and collects two line-anchored annotations](docs/demo.gif)
 
-**Annotate the code, not the chat.** No more dictating "change file X, line
+**Annotate the code, not the prompt.** No more dictating "change file X, line
 Z…" into the prompt. Select the lines in the pane, write the note, tag it
 (`fix` / `verify` / `question` / `nit`) — it flows back to the agent as
 structured, line-anchored output it acts on directly.
 
 **Let the agent walk you through its changes.** In the era of 1000-line
-diffs, reading everything doesn't scale — and agent prose summaries are a
+diffs, reading everything doesn't scale, and agent prose summaries are a
 poor substitute for the code itself. Here the agent drives the pane: it
 jumps you to exactly the parts worth seeing while explaining in chat. Ask
 questions, ask for the next spot — you only see what you need to see.
 
-**Diff or finished state — one key.** Reviewing the changes is the default;
+**Diff or finished state, just a toggle away.** Reviewing the changes is the default;
 press `t` when you just want to read the final version of the file, no diff
 noise.
 
-**A real sign-off gate, when you want one.** In blocking mode the agent is
-*frozen* until your verdict — approve, request changes, or cancel — so
+**A real sign-off gate, if you need it.** In blocking mode the agent is
+*frozen* until your verdict (approve, request changes, or cancel) so
 nothing runs past your review.
 
 Also in the box: full mouse support, syntax-highlighted diffs, a `?`
-key-reference overlay, one-command install with checksum-verified binaries —
+key-reference overlay, one-command install with checksum-verified binaries,
 and an agent that can never be wedged by a closed pane or timeout.
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # herdr-file-annotator
 
-**Code review for AI agents, inside your terminal.** The agent stops and asks
-*you* — in a real review pane, on real diffs, with feedback it can act on.
+**Maximize agentic development — without losing touch with the actual codebase.**
+
+Working with coding agents usually forces a choice: adopt an IDE-style tool
+and leave your terminal workflow behind, or stay in the terminal and squint
+at raw diffs and verbose agent prose in chat. This [herdr](https://herdr.dev)
+plugin removes the choice — when you and your agent need to meet over actual
+code, a review pane opens right in your workspace, and closes when you're
+done.
 
 ![Demo: the agent opens a review pane, walks through the diff while the pane follows, and collects two line-anchored annotations](docs/demo.gif)
 
-Your coding agent reaches a checkpoint and calls one MCP tool. A review pane
-opens beside it in your [herdr](https://herdr.dev) workspace showing only what
-changed. You scroll, annotate lines, pick a verdict — and your review flows
-back to the agent as structured JSON it acts on. No context switch, no
-copy-pasting feedback into chat, no rubber-stamping.
+**Annotate the code, not the chat.** No more dictating "change file X, line
+Z…" into the prompt. Select the lines in the pane, write the note, tag it
+(`fix` / `verify` / `question` / `nit`) — it flows back to the agent as
+structured, line-anchored output it acts on directly.
 
-## Core features
+**Let the agent walk you through its changes.** In the era of 1000-line
+diffs, reading everything doesn't scale — and agent prose summaries are a
+poor substitute for the code itself. Here the agent drives the pane: it
+jumps you to exactly the parts worth seeing while explaining in chat. Ask
+questions, ask for the next spot — you only see what you need to see.
 
-- **A real sign-off gate** — `review_changes` *freezes* the agent until you
-  approve, request changes, or cancel. The agent cannot run past your review.
-- **Guided walkthroughs** — or flip it: the agent opens the pane without
-  blocking, explains the diff in chat while the pane follows its pointer
-  (`show_changes` + `goto`), and collects your verdict when you're done.
-- **Line-anchored annotations** — select a range, comment, tag it
-  (`fix` / `verify` / `question` / `nit`). Notes render inline under the code
-  and return to the agent with exact file/line anchors.
-- **A reviewer's editor, not a toy pane** — syntax-highlighted diffs, a
-  diff ↔ full-source toggle, full mouse support, horizontal panning for wide
-  code, a `?` key-reference overlay, and Unicode-correct rendering down to
-  emoji and Indic conjuncts.
-- **Never wedges your agent** — closed panes, timeouts, and disconnects all
-  resolve to a clean `cancelled` verdict, never a hang.
-- **One-command install** — prebuilt, SHA-256-verified binaries for macOS and
-  Linux; listed on the herdr marketplace.
+**Diff or finished state — one key.** Reviewing the changes is the default;
+press `t` when you just want to read the final version of the file, no diff
+noise.
+
+**A real sign-off gate, when you want one.** In blocking mode the agent is
+*frozen* until your verdict — approve, request changes, or cancel — so
+nothing runs past your review.
+
+Also in the box: full mouse support, syntax-highlighted diffs, a `?`
+key-reference overlay, one-command install with checksum-verified binaries —
+and an agent that can never be wedged by a closed pane or timeout.
 
 ## Quick start
 


### PR DESCRIPTION
## What

The second half of the docs bundle — PR #13 was merged at a stale head (a GitHub sync glitch), taking only the demo-GIF commit; this PR carries the remaining restructure commit.

Pitch-first reading order: one-line hook, the GIF, a what-it-does paragraph, a **Core features** list, and a 3-step **Quick start** — all before any architecture ("That's the whole setup. Everything below is reference."). Detail sections follow with unchanged content; the reviewr/annot positioning moves to **Related projects** near the end.

No factual changes — reorganization plus pitch copy only.

## How was it tested

- [x] Docs-only; all command snippets/tables carried over verbatim
- [x] `cargo test` untouched

## Checklist

- [x] No code changes