### PR TITLE
feat: reviewer-triggered folding in source view

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ noise.
 *frozen* until your verdict (approve, request changes, or cancel) so
 nothing runs past your review.
 
-Also in the box: full mouse support, syntax-highlighted diffs, a `?`
-key-reference overlay, one-command install with checksum-verified binaries,
-and an agent that can never be wedged by a closed pane or timeout.
+Also in the box: full mouse support, syntax-highlighted diffs, code folding
+(fold a long file to just the parts that matter — by hand, or driven by the
+agent as it explains), a `?` key-reference overlay, one-command install with
+checksum-verified binaries, and an agent that can never be wedged by a
+closed pane or timeout.
 
 ## Quick start
 
@@ -66,7 +68,7 @@ That's the whole setup.
 - [Agent setup](docs/agents.md) — registering the MCP server with Claude
   Code, Codex, Gemini CLI, Cursor, and others
 - [Controls](docs/controls.md) — every key and mouse action in the pane
-- [MCP tools](docs/mcp-tools.md) — the four tools, the verdict format, and
+- [MCP tools](docs/mcp-tools.md) — the five tools, the verdict format, and
   guided walkthroughs
 - [Configuration](docs/configuration.md) — pane placement, focus, timeouts
 - [How it works](docs/architecture.md) — the two-mode binary, install

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -71,6 +71,31 @@ no diff noise. Annotations work in both views.
 
 ![Source view: the full finished file with syntax highlighting and no diff markers](img/source-view.png)
 
+## Folding (source view)
+
+Long file, but only a few parts matter right now? Collapse the rest into
+`⋯ N lines folded ⋯` pills — by hand with the keys below, or agent-driven:
+during a guided walkthrough the agent can call its `focus` tool to fold a
+file down to the regions it's explaining (see
+[MCP tools](mcp-tools.md#focus-fold-a-file-to-what-matters)). Both kinds
+share the same behavior, and folding only exists in source view — the diff
+already shows just its hunks.
+
+| Keys | Action |
+|---|---|
+| `f` | fold the selection (`v` + movement first), or — with no selection — the indentation block under the cursor line: `f` on a `def`/`fn` header tucks the body away, the header stays visible |
+| `Enter` (on a pill) | expand that fold |
+| `F` | unfold everything in this file |
+
+Mouse: clicking a pill expands it.
+
+Pills are real cursor stops; movement skips the hidden lines. Very short
+stretches (one or two lines) never fold — a pill would cost as much space
+as it saves. Annotations hidden by a fold aren't lost: the pill shows a
+note badge (`⋯ 24 lines folded · 1 note ⋯`), and expanding brings them
+back inline. An agent `goto` into a folded stretch expands it
+automatically, so you can never be pointed at something you can't see.
+
 ## Finishing the review
 
 | Keys | Action |

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -89,6 +89,13 @@ already shows just its hunks.
 
 Mouse: clicking a pill expands it.
 
+The block detection is indentation-based and language-agnostic (a
+base-indent line opening with `)`, `]`, or `}` still belongs to the block,
+so multi-line signatures fold correctly). It deliberately doesn't track any
+language's real grammar — for a layout it doesn't recognize, such as a Rust
+`where` clause at the header's own indent, select the lines yourself and
+fold with `v` + `f`.
+
 Pills are real cursor stops; movement skips the hidden lines. Very short
 stretches (one or two lines) never fold — a pill would cost as much space
 as it saves. Annotations hidden by a fold aren't lost: the pill shows a

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,17 +1,19 @@
 # MCP tools
 
-Four tools, one shared review protocol. `review_changes` blocks the agent
-until a verdict lands. `show_changes` + `goto` + `collect_review` don't:
-they let the agent open the pane, narrate the diff in chat while pushing
-navigation, and come back for the verdict whenever it's ready. Annotations
-work exactly the same way in both modes, and the reviewer can also just
-finish the review in the pane at any time, without waiting to be asked.
+Five tools, one shared review protocol. `review_changes` blocks the agent
+until a verdict lands. `show_changes` + `goto` + `focus` + `collect_review`
+don't: they let the agent open the pane, narrate the diff in chat while
+pushing navigation, and come back for the verdict whenever it's ready.
+Annotations work exactly the same way in both modes, and the reviewer can
+also just finish the review in the pane at any time, without waiting to be
+asked.
 
 | Tool | Blocks? | Arguments | Returns |
 |------|---------|-----------|---------|
 | `review_changes` | Yes | `baseline?`, `note?`, `working_dir?` | Verdict + annotations (below), once the human decides. |
 | `show_changes` | No | `baseline?`, `note?`, `working_dir?` | `{"opened": true, "working_dir": "..."}` immediately. |
 | `goto` | No | `file` (repo-relative, new/post-change side), `line` (1-based), `view` (optional: `diff` or `source`) | Confirmation text; navigation is advisory. |
+| `focus` | No | `file`, `regions` (array of 1-based inclusive `{start, end}`; empty clears) | Confirmation text; advisory like `goto`. |
 | `collect_review` | No, polls | `wait_seconds?` (0–120, default 0) | Verdict + annotations once landed, else `{"status": "pending", "open_for_secs": N}`. |
 
 `baseline`, `note`, and `working_dir` mean the same thing for `review_changes`
@@ -24,7 +26,7 @@ and `show_changes`:
 | `working_dir` | string | Repo to review. Defaults to the server's working directory.        |
 
 Only one review — blocking or guided — can be open at a time: `review_changes`
-and `show_changes` each refuse to start a second one, and `goto` /
+and `show_changes` each refuse to start a second one, and `goto` / `focus` /
 `collect_review` refuse to run without one already open.
 
 ## Verdict result
@@ -76,8 +78,9 @@ talk you through a diff rather than hand it over cold and wait:
 2. **Navigate while explaining.** The agent calls
    `goto(file="src/retry.rs", line=42)` as it describes each piece; the pane
    jumps to follow along. Passing `view: "source"` shows the full file for
-   context, `view: "diff"` returns to the change. You annotate as usual —
-   annotations work exactly as they do in blocking mode.
+   context, `view: "diff"` returns to the change. For a long file, `focus`
+   (below) folds it down to just the regions under discussion. You annotate
+   as usual — annotations work exactly as they do in blocking mode.
 3. **Collect the verdict when ready.** `collect_review()` checks once;
    `wait_seconds` polls for a bit instead of hand-rolling a retry loop.
    Nothing landed yet returns `{"status": "pending", ...}` — that's normal,
@@ -92,3 +95,26 @@ A prompt that triggers this end to end, with no special setup:
 > Open the changes with show_changes and walk me through them file by file —
 > use goto to jump me to each part as you explain it, then collect my review
 > at the end.
+
+## Focus: fold a file to what matters
+
+`focus(file, regions)` folds the source view of one file down to just the
+named line regions — for walkthroughs of long files where only a few
+functions matter. Everything between the regions collapses into
+`⋯ N lines folded ⋯` pills; the pane switches to that file's source view
+and lands on the first region.
+
+- `regions` is an array of 1-based inclusive `{start, end}` ranges on the
+  post-change file, in the order the agent wants to discuss them. Gaps of
+  one or two lines between regions stay visible.
+- Calling `focus` again with new regions refocuses; an **empty** `regions`
+  array clears the focus (whole file visible again, the reviewer's cursor
+  stays put).
+- The reviewer is never trapped: pills expand with `Enter` or a click, `F`
+  reveals the whole file, and a later `goto` into a folded stretch expands
+  it automatically. The reviewer can also fold regions by hand with `f` —
+  see [Controls — folding](controls.md#folding-source-view).
+- Advisory like `goto`: unknown files and out-of-range regions are
+  normalized or ignored by the pane, never an error. Annotations hidden by
+  a fold surface as a note badge on the pill and ride back with the verdict
+  regardless.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -108,8 +108,8 @@ and lands on the first region.
   post-change file, in the order the agent wants to discuss them. Gaps of
   one or two lines between regions stay visible.
 - Calling `focus` again with new regions refocuses; an **empty** `regions`
-  array clears the focus (whole file visible again, the reviewer's cursor
-  stays put).
+  array clears the agent's focus (the reviewer's cursor stays put). Folds the
+  reviewer made by hand with `f` are untouched by this — `F` clears those.
 - The reviewer is never trapped: pills expand with `Enter` or a click, `F`
   reveals the whole file, and a later `goto` into a folded stretch expands
   it automatically. The reviewer can also fold regions by hand with `f` —

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -178,7 +178,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": FOCUS,
-            "description": "Fold the review pane's source view of one file down to just the line regions you name — for guided walkthroughs of long files where only a few parts matter. Everything between the regions collapses into '⋯ N lines folded ⋯' pills the reviewer can expand with Enter or a click; the pane switches to that file's source view and lands on the first region. Regions are 1-based inclusive {start, end} ranges on the new (post-change) side, listed in the order you'll discuss them; gaps of one or two lines between regions stay visible. Call again with new regions to refocus, or with an empty regions array to clear the focus (whole file visible again, cursor left where the reviewer had it). A later goto into a folded stretch expands it automatically, so you can never strand the reviewer behind a fold. Advisory like goto: unknown files and out-of-range regions are normalized or ignored by the pane, never an error here. Requires an open review — call show_changes first.",
+            "description": "Fold the review pane's source view of one file down to just the line regions you name — for guided walkthroughs of long files where only a few parts matter. Everything between the regions collapses into '⋯ N lines folded ⋯' pills the reviewer can expand with Enter or a click; the pane switches to that file's source view and lands on the first region. Regions are 1-based inclusive {start, end} ranges on the new (post-change) side, listed in the order you'll discuss them; gaps of one or two lines between regions stay visible. Call again with new regions to refocus, or with an empty regions array to clear the agent's focus (cursor left where the reviewer had it). This does not touch folds the reviewer made by hand with f — those stay in place until the reviewer expands them or presses F. A later goto into a folded stretch expands it automatically, so you can never strand the reviewer behind a fold. Advisory like goto: unknown files and out-of-range regions are normalized or ignored by the pane, never an error here. Requires an open review — call show_changes first.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -358,7 +358,9 @@ fn handle_focus(args: &Value, active: &mut Option<ActiveReview>) -> Value {
         None => (0, None),
     };
     let summary = if regions.is_empty() {
-        format!("cleared the focus on {file} — the whole file is visible again, cursor untouched")
+        format!(
+            "cleared the focus on {file} — cursor untouched (folds the reviewer made by hand with f, if any, are unaffected)"
+        )
     } else {
         let list = regions
             .iter()
@@ -663,6 +665,26 @@ mod tests {
         assert!(
             cleared["content"][0]["text"].as_str().unwrap().contains("cleared"),
             "{cleared}"
+        );
+
+        release_tx.send(()).unwrap();
+        let _ = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        pane.join().unwrap();
+    }
+
+    // A reviewer-made manual fold (from `f`) isn't touched by clearing the
+    // agent's focus, so the reply must not claim the whole file becomes
+    // visible again — only that the agent's own focus is gone.
+    #[test]
+    fn focus_clear_message_does_not_overclaim_full_file_visibility() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let mut active = Some(active_review);
+
+        let cleared = handle_focus(&json!({ "file": "src/a.rs", "regions": [] }), &mut active);
+        let text = cleared["content"][0]["text"].as_str().unwrap();
+        assert!(
+            !text.contains("whole file is visible"),
+            "manual folds from f survive a focus clear, so this overclaims: {text}"
         );
 
         release_tx.send(()).unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -456,6 +456,14 @@ fn merge_runs(mut runs: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
 /// leading whitespace characters — comparisons stay within one file, where
 /// indentation style is consistent, so tabs-vs-spaces width games don't
 /// change any ordering this cares about.
+///
+/// DELIBERATE boundary (PR #17 review): the heuristic is structural, never
+/// grammatical — it recognizes closing delimiters at base indent (below)
+/// but no language keywords, so e.g. a rustfmt-style `where` clause at the
+/// header's own indent ends the block early. Recognizing it would mean
+/// hardcoding per-language keywords and invite endless special-casing;
+/// the documented fallback for unrecognized layouts is selecting the rows
+/// and folding with `v` + `f`.
 fn indent_block_below(lines: &[String], row: usize) -> Option<(usize, usize)> {
     fn indent_of(line: &str) -> Option<usize> {
         let trimmed = line.trim_start();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -433,6 +433,54 @@ fn fold_run_containing(runs: &[(usize, usize)], base: usize) -> Option<(usize, u
     runs.iter().copied().find(|&(s, e)| s <= base && base <= e)
 }
 
+/// Normalize a bag of fold runs into the sorted, disjoint form the display
+/// math needs: overlapping and directly adjacent runs merge into one
+/// (adjacent because two touching pills read as one collapsed stretch and
+/// should cost one row, not two).
+fn merge_runs(mut runs: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    runs.sort_unstable();
+    let mut merged: Vec<(usize, usize)> = Vec::new();
+    for (s, e) in runs {
+        match merged.last_mut() {
+            Some((_, le)) if s <= *le + 1 => *le = (*le).max(e),
+            _ => merged.push((s, e)),
+        }
+    }
+    merged
+}
+
+/// The foldable block UNDER `row`: the run of following lines strictly more
+/// indented than `row`'s line, with interior blank lines belonging to the
+/// block and trailing blank lines trimmed off it. `None` when `row` is
+/// blank, out of range, or heads no block. Indentation is measured in
+/// leading whitespace characters — comparisons stay within one file, where
+/// indentation style is consistent, so tabs-vs-spaces width games don't
+/// change any ordering this cares about.
+fn indent_block_below(lines: &[String], row: usize) -> Option<(usize, usize)> {
+    fn indent_of(line: &str) -> Option<usize> {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            None // blank lines have no indent identity
+        } else {
+            Some(line.len() - trimmed.len())
+        }
+    }
+    let base = indent_of(lines.get(row)?)?;
+    let mut end = row; // last row CONFIRMED to belong to the block
+    let mut i = row + 1;
+    while i < lines.len() {
+        match indent_of(&lines[i]) {
+            // Blank: tentatively part of the block — confirmed only if a
+            // deeper-indented line follows, otherwise it trails and trims.
+            None => {}
+            Some(ind) if ind > base => end = i,
+            Some(_) => break,
+        }
+        i += 1;
+    }
+    (end > row).then_some((row + 1, end))
+}
+
 /// True when `base` is a fold HEAD: the row rendered as the pill.
 fn is_fold_head(runs: &[(usize, usize)], base: usize) -> bool {
     runs.iter().any(|&(s, _)| s == base)
@@ -882,6 +930,11 @@ struct App<'a> {
     /// new focus push replaces that file's regions — a fresh focus starts
     /// fresh.
     folds_expanded: HashMap<usize, Vec<(usize, usize)>>,
+    /// Folds the reviewer created by hand (`f` on a selection or on a
+    /// block header), per file: base-row runs collapsed in source view,
+    /// independent of any agent focus. Normalized (sorted, merged) on
+    /// insertion; `active_folds` unions them with the focus-derived runs.
+    manual_folds: HashMap<usize, Vec<(usize, usize)>>,
 }
 
 /// The file's current modification time, or `None` if it can't be stat'd
@@ -898,6 +951,10 @@ fn file_mtime(working_dir: &str, path: &str) -> Option<std::time::SystemTime> {
 struct SourceFile {
     lines: Vec<Line<'static>>,
     count: usize,
+    /// The raw source text, one entry per line — kept alongside the
+    /// rendered rows because fold-by-indentation needs to measure leading
+    /// whitespace, which the highlighted spans no longer expose cleanly.
+    raw: Vec<String>,
 }
 
 /// The pinned-span count `pan_and_clip` uses for a row (gutter + origin
@@ -987,6 +1044,7 @@ impl<'a> App<'a> {
             help_scroll: 0,
             focus_regions: HashMap::new(),
             folds_expanded: HashMap::new(),
+            manual_folds: HashMap::new(),
         }
     }
 
@@ -1110,7 +1168,7 @@ impl<'a> App<'a> {
                 Ok(lines) => {
                     let rows = highlight_source_rows(highlighter(), &path, &lines);
                     self.pan_limit.insert((idx, ViewMode::Source), pan_cap_for_rows(&rows));
-                    Ok(SourceFile { lines: rows, count: lines.len() })
+                    Ok(SourceFile { lines: rows, count: lines.len(), raw: lines })
                 }
                 Err(err) => Err(err.root_cause().to_string()),
             }
@@ -1287,10 +1345,11 @@ impl<'a> App<'a> {
         self.diff.cursor = row;
         // A goto into a folded stretch reveals it — the agent must never
         // point the reviewer at a row the pane is hiding (the pill head
-        // included: its own line's content is behind the pill too).
+        // included: its own line's content is behind the pill too). Manual
+        // folds count: hand-folded or agent-folded, hidden is hidden.
         let folds = self.active_folds();
         if let Some(run) = fold_run_containing(&folds, row) {
-            self.folds_expanded.entry(self.nav.selected).or_default().push(run);
+            self.expand_run(run);
         }
         self.focus = Focus::Diff;
         self.ensure_cursor_visible(term_size);
@@ -1580,18 +1639,30 @@ impl<'a> App<'a> {
         if self.view != ViewMode::Source {
             return Vec::new();
         }
-        let Some(regions) = self.focus_regions.get(&self.nav.selected) else {
-            return Vec::new();
-        };
         let count = self.source_line_count();
         if count == 0 {
             return Vec::new();
         }
-        let mut runs = fold_runs(regions, count);
-        if let Some(expanded) = self.folds_expanded.get(&self.nav.selected) {
-            runs.retain(|r| !expanded.contains(r));
+        let mut runs: Vec<(usize, usize)> = Vec::new();
+        if let Some(regions) = self.focus_regions.get(&self.nav.selected) {
+            let mut derived = fold_runs(regions, count);
+            if let Some(expanded) = self.folds_expanded.get(&self.nav.selected) {
+                derived.retain(|r| !expanded.contains(r));
+            }
+            runs.extend(derived);
         }
-        runs
+        if let Some(manual) = self.manual_folds.get(&self.nav.selected) {
+            runs.extend(manual.iter().copied());
+        }
+        merge_runs(runs)
+    }
+
+    /// The selected file's raw source lines, when its source is usable.
+    fn source_raw(&self) -> Option<&[String]> {
+        match self.source_cache.get(&self.nav.selected) {
+            Some(Ok(source)) => Some(&source.raw),
+            _ => None,
+        }
     }
 
     /// After a cursor move landed inside a fold's hidden tail: moving down
@@ -1614,7 +1685,94 @@ impl<'a> App<'a> {
         let folds = self.active_folds();
         if let Some(run) = fold_run_containing(&folds, self.diff.cursor) {
             if run.0 == self.diff.cursor {
-                self.folds_expanded.entry(self.nav.selected).or_default().push(run);
+                self.expand_run(run);
+            }
+        }
+    }
+
+    /// Reveal one displayed run. A displayed run can be a merger of manual
+    /// folds and focus-derived folds, so expansion dismantles every
+    /// constituent it intersects: manual runs are deleted outright, derived
+    /// runs go onto the expanded list `active_folds` subtracts.
+    fn expand_run(&mut self, run: (usize, usize)) {
+        let idx = self.nav.selected;
+        let count = self.source_line_count();
+        if let Some(manual) = self.manual_folds.get_mut(&idx) {
+            manual.retain(|&(s, e)| e < run.0 || run.1 < s);
+        }
+        if self.manual_folds.get(&idx).is_some_and(|m| m.is_empty()) {
+            self.manual_folds.remove(&idx);
+        }
+        if let Some(regions) = self.focus_regions.get(&idx) {
+            let derived = fold_runs(regions, count);
+            let expanded = self.folds_expanded.entry(idx).or_default();
+            for d in derived.into_iter().filter(|&(s, e)| s <= run.1 && run.0 <= e) {
+                if !expanded.contains(&d) {
+                    expanded.push(d);
+                }
+            }
+        }
+    }
+
+    /// `f` in source view: fold the visual selection if one is active,
+    /// otherwise the indentation block UNDER the cursor line (the header
+    /// line itself stays visible — `f` on a `def`/`fn` line tucks the body
+    /// away). Runs shorter than `MIN_FOLD_LINES` don't fold, same as the
+    /// focus path. No-op in diff view and on files with no usable source.
+    fn fold_at_cursor_or_selection(&mut self) {
+        if self.view != ViewMode::Source {
+            return;
+        }
+        let count = self.source_line_count();
+        if count == 0 {
+            return;
+        }
+        let run = match self.visual_anchor {
+            Some(anchor) => {
+                let s = anchor.min(self.diff.cursor);
+                let e = anchor.max(self.diff.cursor).min(count - 1);
+                (s, e)
+            }
+            None => {
+                let Some(raw) = self.source_raw() else { return };
+                match indent_block_below(raw, self.diff.cursor) {
+                    Some(run) => run,
+                    None => return,
+                }
+            }
+        };
+        if run.1 - run.0 + 1 < MIN_FOLD_LINES {
+            return;
+        }
+        self.visual_anchor = None;
+        let entry = self.manual_folds.entry(self.nav.selected).or_default();
+        entry.push(run);
+        *entry = merge_runs(std::mem::take(entry));
+        // A cursor inside the new fold's tail lands on its pill — for a
+        // selection fold that's the collapsed range's head; a block fold
+        // leaves the cursor on the still-visible header line above it.
+        if let Some(r) = fold_run_containing(&self.active_folds(), self.diff.cursor) {
+            self.diff.cursor = r.0;
+        }
+    }
+
+    /// `F` in source view: reveal everything in this file — manual folds
+    /// are deleted, focus-derived folds are all marked expanded. The stored
+    /// focus regions survive, so a fresh agent push starts from its own
+    /// clean slate rather than resurrecting what the reviewer dismissed.
+    fn unfold_all(&mut self) {
+        if self.view != ViewMode::Source {
+            return;
+        }
+        let idx = self.nav.selected;
+        self.manual_folds.remove(&idx);
+        if let Some(regions) = self.focus_regions.get(&idx) {
+            let derived = fold_runs(regions, self.source_line_count());
+            let expanded = self.folds_expanded.entry(idx).or_default();
+            for d in derived {
+                if !expanded.contains(&d) {
+                    expanded.push(d);
+                }
             }
         }
     }
@@ -1997,6 +2155,8 @@ impl<'a> App<'a> {
                     KeyCode::Char('x') => self.delete_pending_at_cursor(),
                     KeyCode::Char('t') => self.toggle_view(term_size),
                     KeyCode::Enter => self.expand_fold_at_cursor(),
+                    KeyCode::Char('f') => self.fold_at_cursor_or_selection(),
+                    KeyCode::Char('F') => self.unfold_all(),
                     _ => {}
                 }
                 // Any move that landed inside a fold's hidden tail continues
@@ -2097,8 +2257,12 @@ impl<'a> App<'a> {
                         HelpRow::new("h / tab", "focus the files"),
                         HelpRow::new("t", "toggle diff / source view"),
                     ];
-                    // Only meaningful while the agent has folded this file
-                    // down to its focus regions.
+                    // Folding lives in source view only: the diff already
+                    // shows just its hunks.
+                    if self.view == ViewMode::Source {
+                        rows.push(HelpRow::new("f", "fold the selection / the block under the cursor"));
+                        rows.push(HelpRow::new("F", "unfold everything in this file"));
+                    }
                     if !self.active_folds().is_empty() {
                         rows.push(HelpRow::new("enter", "expand the fold under the cursor"));
                     }
@@ -3689,6 +3853,189 @@ mod tests {
         let visible_comment_rows =
             comment_height(None, "note", 80);
         assert_eq!(map.total(40), 40 - 8 - 13 - 4 + visible_comment_rows);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn indent_block_below_finds_the_body_and_trims_trailing_blanks() {
+        let lines: Vec<String> = [
+            "def outer():",      // 0
+            "    a = 1",         // 1
+            "    if a:",         // 2
+            "        b = 2",     // 3
+            "",                  // 4 (interior blank)
+            "        c = 3",     // 5
+            "    return a",      // 6
+            "",                  // 7 (trailing blank)
+            "def next_fn():",    // 8
+            "    pass",          // 9
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        // The whole body under the def, interior blank included, trailing
+        // blank trimmed.
+        assert_eq!(indent_block_below(&lines, 0), Some((1, 6)));
+        // A nested block: everything deeper than the `if`.
+        assert_eq!(indent_block_below(&lines, 2), Some((3, 5)));
+        // A leaf line heads no block.
+        assert_eq!(indent_block_below(&lines, 1), None);
+        // Blank lines and out-of-range rows head nothing.
+        assert_eq!(indent_block_below(&lines, 4), None);
+        assert_eq!(indent_block_below(&lines, 99), None);
+        // The last def's body runs to the end of the file.
+        assert_eq!(indent_block_below(&lines, 8), Some((9, 9)));
+    }
+
+    #[test]
+    fn merge_runs_unions_overlapping_and_adjacent_runs() {
+        assert_eq!(merge_runs(vec![(10, 20), (0, 5)]), vec![(0, 5), (10, 20)]);
+        assert_eq!(merge_runs(vec![(0, 8), (9, 12)]), vec![(0, 12)]); // adjacent
+        assert_eq!(merge_runs(vec![(0, 8), (5, 12), (12, 20)]), vec![(0, 20)]);
+        assert_eq!(merge_runs(vec![]), Vec::<(usize, usize)>::new());
+    }
+
+    #[test]
+    fn manual_selection_fold_collapses_and_enter_expands_it() {
+        let (dir, request, model) = fold_fixture("manual");
+        let request: &'static ReviewRequest = Box::leak(Box::new(request.clone()));
+        let model: &'static Result<DiffModel> = Box::leak(Box::new(match &model {
+            Ok(m) => Ok(DiffModel { files: m.files.clone() }),
+            Err(_) => unreachable!(),
+        }));
+        let mut app = App::new(request, model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+        // Into source view with NO agent focus: manual folding stands alone.
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 11, view: Some("source".into()), focus: None },
+            size,
+        );
+        assert!(app.active_folds().is_empty());
+
+        // v, five rows down, f: rows 10..=15 fold.
+        app.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), size);
+        for _ in 0..5 {
+            app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert_eq!(app.active_folds(), vec![(10, 15)]);
+        assert_eq!(app.diff.cursor, 10, "the cursor lands on the new pill");
+        assert!(app.visual_anchor.is_none(), "folding consumes the selection");
+
+        // Movement treats it like any fold; Enter dismantles it for good.
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        assert_eq!(app.diff.cursor, 16);
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE), size);
+        assert_eq!(app.diff.cursor, 10);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+        assert!(app.active_folds().is_empty());
+        assert!(app.manual_folds.is_empty(), "an expanded manual fold is deleted, not parked");
+
+        // A too-short selection folds nothing (same MIN_FOLD_LINES floor as
+        // the focus path); on this flat file `f` without a selection heads
+        // no indent block, so it's a no-op too.
+        app.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert!(app.active_folds().is_empty());
+        app.visual_anchor = None;
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert!(app.active_folds().is_empty());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn block_fold_hides_the_body_and_keeps_the_header_visible() {
+        let dir = std::env::temp_dir()
+            .join(format!("herdr-annotator-fold-block-{}", std::process::id()));
+        std::fs::create_dir_all(dir.join("src")).expect("temp dir");
+        let body = "def outer():\n    a = 1\n    b = 2\n    c = 3\n    return a\n\ndef next_fn():\n    pass\n";
+        std::fs::write(dir.join("src/lib.rs"), body).expect("write source");
+        let request: &'static ReviewRequest = Box::leak(Box::new(ReviewRequest {
+            version: 1,
+            working_dir: dir.to_string_lossy().into_owned(),
+            baseline: None,
+            note: None,
+        }));
+        let model: &'static Result<DiffModel> =
+            Box::leak(Box::new(Ok(DiffModel { files: vec![sample_file()] })));
+        let mut app = App::new(request, model);
+        app.focus = Focus::Diff;
+        let size = Size::new(120, 40);
+        app.apply_goto(
+            &GotoTarget { file: "src/lib.rs".into(), line: 1, view: Some("source".into()), focus: None },
+            size,
+        );
+
+        // f on the def line: the body (rows 1..=4) folds, the header stays.
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert_eq!(app.active_folds(), vec![(1, 4)]);
+        assert_eq!(app.diff.cursor, 0, "the header line keeps the cursor");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unfold_all_clears_manual_folds_and_expands_the_focus_ones() {
+        let (dir, request, model) = fold_fixture("unfoldall");
+        let mut app = focused_app(&request, &model);
+        let size = Size::new(120, 40);
+        assert_eq!(app.active_folds(), vec![(0, 8), (15, 28), (35, 39)]);
+
+        // Add a manual fold in the visible region: rows 10..=12.
+        app.diff.cursor = 10;
+        app.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert_eq!(app.active_folds(), vec![(0, 8), (10, 12), (15, 28), (35, 39)]);
+
+        app.handle_key(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::NONE), size);
+        assert!(app.active_folds().is_empty(), "F reveals the whole file");
+        assert!(
+            app.focus_regions.contains_key(&0),
+            "the stored focus survives — a fresh agent push starts clean"
+        );
+        // And a fresh push does re-fold.
+        app.apply_goto(
+            &GotoTarget {
+                file: "src/lib.rs".into(),
+                line: 10,
+                view: None,
+                focus: Some(vec![lr(10, 15)]),
+            },
+            size,
+        );
+        assert_eq!(app.active_folds(), vec![(0, 8), (15, 39)]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn expanding_a_merged_manual_and_focus_run_dismantles_both() {
+        let (dir, request, model) = fold_fixture("merged");
+        let mut app = focused_app(&request, &model);
+        let size = Size::new(120, 40);
+
+        // Manual fold rows 9..=15 (six j's — the sixth stops on the (15,28)
+        // pill head): adjacent to the (0,8) focus fold and touching the
+        // (15,28) one — the display shows ONE merged pill spanning (0,28).
+        app.diff.cursor = 9;
+        app.handle_key(KeyEvent::new(KeyCode::Char('v'), KeyModifiers::NONE), size);
+        for _ in 0..6 {
+            app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE), size);
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE), size);
+        assert_eq!(app.active_folds(), vec![(0, 28), (35, 39)]);
+        assert_eq!(app.diff.cursor, 0, "cursor snaps to the merged pill's head");
+
+        // Enter dismantles every constituent the merged run covers.
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE), size);
+        assert_eq!(app.active_folds(), vec![(35, 39)]);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -465,6 +465,9 @@ fn indent_block_below(lines: &[String], row: usize) -> Option<(usize, usize)> {
             Some(line.len() - trimmed.len())
         }
     }
+    fn starts_closing(line: &str) -> bool {
+        matches!(line.trim_start().chars().next(), Some(')' | ']' | '}'))
+    }
     let base = indent_of(lines.get(row)?)?;
     let mut end = row; // last row CONFIRMED to belong to the block
     let mut i = row + 1;
@@ -474,6 +477,14 @@ fn indent_block_below(lines: &[String], row: usize) -> Option<(usize, usize)> {
             // deeper-indented line follows, otherwise it trails and trims.
             None => {}
             Some(ind) if ind > base => end = i,
+            // A base-indent line that OPENS with a closing delimiter still
+            // belongs to the block it closes — the `):` ending a multi-line
+            // def, the `}` ending a braced body, a `} else {` chain link.
+            // Without this the scan breaks at the closing delimiter of the
+            // header's own signature and folds only the parameter lines.
+            // (Only at exactly base indent: shallower means an OUTER scope
+            // is closing, and that block this row does not belong to.)
+            Some(ind) if ind == base && starts_closing(&lines[i]) => end = i,
             Some(_) => break,
         }
         i += 1;
@@ -3887,6 +3898,51 @@ mod tests {
         assert_eq!(indent_block_below(&lines, 99), None);
         // The last def's body runs to the end of the file.
         assert_eq!(indent_block_below(&lines, 8), Some((9, 9)));
+    }
+
+    #[test]
+    fn indent_block_below_carries_past_closing_delimiters_at_base_indent() {
+        // The Codex-reported case: a multi-line signature's closing `):`
+        // (or `) {` / `}`) sits at the HEADER's indent — it belongs to the
+        // block, it doesn't end it.
+        let python: Vec<String> = [
+            "def fetch(",       // 0
+            "    url,",         // 1
+            "    attempts=3,",  // 2
+            "):",               // 3 — closing delimiter at base indent
+            "    body()",       // 4
+            "    more()",       // 5
+            "next_stmt()",      // 6
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(indent_block_below(&python, 0), Some((1, 5)));
+
+        let rust: Vec<String> = [
+            "fn fetch(",             // 0
+            "    url: &str,",        // 1
+            ") -> Result<()> {",     // 2
+            "    body();",           // 3
+            "}",                     // 4 — the whole body folds, brace included
+            "fn next_fn() {}",       // 5
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(indent_block_below(&rust, 0), Some((1, 4)));
+
+        // A closing delimiter SHALLOWER than the header closes an outer
+        // scope — that ends the block, it doesn't extend it.
+        let nested: Vec<String> = [
+            "    if a {",   // 0 (base indent 4)
+            "        b();", // 1
+            "}",            // 2 — outer scope's brace, indent 0
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(indent_block_below(&nested, 0), Some((1, 1)));
     }
 
     #[test]


### PR DESCRIPTION
The user-triggered half of the folding feature (PR #16 shipped the agent-driven half):

- **`f`** folds the visual selection — or, with no selection, the **indentation block under the cursor line**: `f` on a `def`/`fn` header tucks the body away while the signature stays visible (verified live: `f` on `def fetch` collapsed its 8-line body into a pill, header intact).
- **`F`** reveals the whole file: manual folds are deleted, agent-focus folds are all marked expanded. The stored focus regions survive, so a fresh agent `focus` push starts from its own clean slate rather than resurrecting what the reviewer dismissed.
- **One fold engine.** Manual and focus-derived folds union into disjoint runs (adjacent/overlapping runs merge into one pill); expanding a merged pill dismantles every constituent it covers, whether hand- or agent-made. Movement, `Enter`/click expansion, goto auto-expand, the `MIN_FOLD_LINES` floor, and note badges all behave identically for both kinds — hidden is hidden, whoever folded it.
- Indent detection is a pure function over the raw source lines (now kept alongside the highlighted rows): interior blank lines belong to a block, trailing blanks trim off, and comparisons stay within one file so tab-width games don't matter.

Also carries the docs follow-up owed from #16's review: the `focus` tool is now documented in `docs/mcp-tools.md` (closing the open Codex thread there), `docs/controls.md` gains a Folding section, and the README mentions folding.

125 tests pass (7 new: indent-block extraction, run merging, selection/block folds, unfold-all, merged-pill expansion), build warning-free, `f`/`F` verified against a live pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)