### PR TITLE
Verdict nudge: automatic agent continuation for non-blocking reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ structured, line-anchored output it acts on directly.
 diffs, reading everything doesn't scale, and agent prose summaries are a
 poor substitute for the code itself. Here the agent drives the pane: it
 jumps you to exactly the parts worth seeing while explaining in chat. Ask
-questions, ask for the next spot — you only see what you need to see.
+questions, ask for the next spot — you only see what you need to see. And
+when you finish in the pane, the agent picks your feedback up on its own —
+no "I'm done" prompt needed.
 
 **Diff or finished state, just a toggle away.** Reviewing the changes is the default;
 press `t` when you just want to read the final version of the file, no diff

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ herdr plugin config-dir jonasbaeumer.file-annotator
 | `focus` | `true` | Move keyboard focus to the review pane when it opens |
 | `accept_timeout_secs` | `20` | How long the agent waits for the pane to appear |
 | `review_timeout_secs` | unset | If set, a review left open this long returns a `cancelled` verdict |
+| `notify_on_verdict` | `true` | Nudge the agent (a short prompt typed into its pane) when a non-blocking review finishes with no `collect_review` waiting — see [MCP tools](mcp-tools.md#automatic-continuation-the-verdict-nudge) |
 
 Example — open reviews as a tab, and auto-cancel anything left open for an
 hour:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -86,7 +86,45 @@ talk you through a diff rather than hand it over cold and wait:
    Nothing landed yet returns `{"status": "pending", ...}` — that's normal,
    the agent just calls it again later. You can also finish in the pane on
    your own schedule at any point; a pane closed without a decision surfaces
-   as a normal `cancelled` verdict, not an error.
+   as a normal `cancelled` verdict, not an error. And if the agent has gone
+   idle by the time you finish, the verdict nudge (below) wakes it for you —
+   you never have to tell it you're done.
+
+## Automatic continuation: the verdict nudge
+
+A non-blocking review has a gap: the agent opens the pane, goes idle, you
+review and finish — and nothing tells the agent feedback is waiting. MCP has
+no way for a server to wake an idle agent, but herdr does: the server knows
+which pane the agent lives in.
+
+So when a verdict lands and no `collect_review` call is waiting on it, the
+server types one line into the agent's own chat and submits it:
+
+> [herdr-annotator] The reviewer finished: request_changes with 3
+> annotations. Call collect_review to fetch the feedback and act on it.
+
+The agent wakes, calls `collect_review`, and acts — a full round trip with
+no human dispatching. The nudge carries only the verdict name and the
+annotation count; the feedback itself stays behind `collect_review`, so the
+verdict is still consumed exactly once through the normal tool path. A pane
+closed without a decision nudges too ("closed without a verdict"), so the
+agent always learns the review is over.
+
+Details worth knowing:
+
+- **No double delivery.** While a `collect_review` call is polling, the
+  nudge is suppressed — the verdict arrives as that call's return value.
+  `review_changes` never nudges; it's blocking, the verdict is its return
+  value.
+- **It looks like you typed it.** The nudge lands in the agent's input as a
+  normal prompt (that's the only door into an idle agent). The
+  `[herdr-annotator]` prefix marks where it came from.
+- **A draft in the input box** gets the nudge appended to it — rare, and
+  worth knowing about; fix up the draft and carry on.
+- **Turning it off:** set `notify_on_verdict = false` in the
+  [config](configuration.md), and collect with `collect_review` as before.
+- It works for any agent CLI running in a herdr pane — nothing about it is
+  specific to one agent.
 
 ![The review pane mid-walkthrough: agent-driven navigation landed on the retry loop, with two annotations already left inline](img/annotations-inline.png)
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -119,8 +119,10 @@ Details worth knowing:
 - **It looks like you typed it.** The nudge lands in the agent's input as a
   normal prompt (that's the only door into an idle agent). The
   `[herdr-annotator]` prefix marks where it came from.
-- **A draft in the input box** gets the nudge appended to it — rare, and
-  worth knowing about; fix up the draft and carry on.
+- **A draft in the input box** gets the nudge appended to it and submitted
+  along with it — rare, and worth knowing about; if a half-typed instruction
+  went through, restate it. The server cannot see or preserve the pane's
+  input, so this is inherent to typing into the agent's chat.
 - **Turning it off:** set `notify_on_verdict = false` in the
   [config](configuration.md), and collect with `collect_review` as before.
 - It works for any agent CLI running in a herdr pane — nothing about it is

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct Config {
     pub focus: bool,
     pub accept_timeout: Duration,
     pub review_timeout: Option<Duration>,
+    /// When a non-blocking review's verdict lands with no `collect_review`
+    /// call waiting on it, type a short prompt into the agent's pane so the
+    /// agent picks the feedback up on its own.
+    pub notify_on_verdict: bool,
 }
 
 impl Default for Config {
@@ -51,6 +55,7 @@ impl Default for Config {
             focus: true,
             accept_timeout: Duration::from_secs(DEFAULT_ACCEPT_TIMEOUT_SECS),
             review_timeout: None,
+            notify_on_verdict: true,
         }
     }
 }
@@ -65,6 +70,7 @@ struct RawConfig {
     focus: Option<bool>,
     accept_timeout_secs: Option<u64>,
     review_timeout_secs: Option<u64>,
+    notify_on_verdict: Option<bool>,
 }
 
 /// Load the plugin config, falling back to defaults on any problem. Never
@@ -146,6 +152,7 @@ fn validate(raw: RawConfig) -> Result<Config, String> {
         focus,
         accept_timeout,
         review_timeout,
+        notify_on_verdict: raw.notify_on_verdict.unwrap_or(default.notify_on_verdict),
     })
 }
 
@@ -195,6 +202,7 @@ mod tests {
         assert!(config.focus);
         assert_eq!(config.accept_timeout, Duration::from_secs(20));
         assert_eq!(config.review_timeout, None);
+        assert!(config.notify_on_verdict, "the nudge is on unless the config turns it off");
     }
 
     #[test]
@@ -206,6 +214,7 @@ mod tests {
             focus = false
             accept_timeout_secs = 5
             review_timeout_secs = 600
+            notify_on_verdict = false
             "#,
         )
         .unwrap();
@@ -215,6 +224,7 @@ mod tests {
         assert!(!config.focus);
         assert_eq!(config.accept_timeout, Duration::from_secs(5));
         assert_eq!(config.review_timeout, Some(Duration::from_secs(600)));
+        assert!(!config.notify_on_verdict);
     }
 
     #[test]

--- a/src/herdr.rs
+++ b/src/herdr.rs
@@ -35,6 +35,32 @@ pub fn inside_herdr() -> bool {
     std::env::var("HERDR_ENV").as_deref() == Ok("1")
 }
 
+/// Type `message` into the agent's own pane and submit it with Enter — the
+/// verdict nudge. The MCP server is a child of the agent process, so
+/// HERDR_PANE_ID names the pane whose chat input the message lands in.
+pub fn nudge_agent_pane(message: &str) -> Result<()> {
+    let pane_id = std::env::var("HERDR_PANE_ID")
+        .context("HERDR_PANE_ID is not set — cannot deliver the verdict nudge")?;
+    for args in [
+        vec!["pane", "send-text", &pane_id, message],
+        vec!["pane", "send-keys", &pane_id, "enter"],
+    ] {
+        let output = Command::new(herdr_bin())
+            .args(&args)
+            .output()
+            .context("spawning herdr CLI for the verdict nudge")?;
+        if !output.status.success() {
+            bail!(
+                "`herdr {} {}` failed: {}",
+                args[0],
+                args[1],
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Open the review pane beside the calling agent's pane, injecting the handoff
 /// socket path. herdr CLI server errors arrive as JSON on stderr with exit 1.
 ///
@@ -117,6 +143,63 @@ mod tests {
         assert!(result.is_ok(), "zero exit must be Ok: {result:?}");
         let argv = std::fs::read_to_string(&log).unwrap();
         assert_eq!(argv.trim(), "pane zoom --current --toggle");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Like `fake_herdr`, but appends to the log — the nudge makes two CLI
+    /// calls and both argvs need to survive.
+    fn fake_herdr_appending(dir: &Path, exit_code: i32) -> (PathBuf, PathBuf) {
+        std::fs::create_dir_all(dir).unwrap();
+        let log = dir.join("argv.log");
+        let script = dir.join("herdr-fake.sh");
+        std::fs::write(
+            &script,
+            format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nexit {}\n", log.display(), exit_code),
+        )
+        .unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (script, log)
+    }
+
+    #[test]
+    fn nudge_types_the_message_into_the_agents_pane_and_submits_it() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("annot-nudge-ok-{}", std::process::id()));
+        let (script, log) = fake_herdr_appending(&dir, 0);
+        std::env::set_var("HERDR_BIN_PATH", &script);
+        std::env::set_var("HERDR_PANE_ID", "pane-42");
+        let result = nudge_agent_pane("review closed: approve");
+        std::env::remove_var("HERDR_PANE_ID");
+        std::env::remove_var("HERDR_BIN_PATH");
+
+        assert!(result.is_ok(), "zero exits must be Ok: {result:?}");
+        let argv = std::fs::read_to_string(&log).unwrap();
+        assert_eq!(
+            argv,
+            "pane send-text pane-42 review closed: approve\npane send-keys pane-42 enter\n"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn nudge_without_a_pane_id_is_an_error_not_a_stray_message() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("HERDR_PANE_ID");
+        let result = nudge_agent_pane("review closed: approve");
+        assert!(result.is_err(), "no HERDR_PANE_ID must surface as Err for the caller to log");
+    }
+
+    #[test]
+    fn nudge_surfaces_a_failed_cli_call_as_an_error() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("annot-nudge-err-{}", std::process::id()));
+        let (script, _log) = fake_herdr_appending(&dir, 1);
+        std::env::set_var("HERDR_BIN_PATH", &script);
+        std::env::set_var("HERDR_PANE_ID", "pane-42");
+        let result = nudge_agent_pane("review closed: approve");
+        std::env::remove_var("HERDR_PANE_ID");
+        std::env::remove_var("HERDR_BIN_PATH");
+        assert!(result.is_err(), "nonzero exit must be Err so the caller can log it");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -22,7 +22,8 @@
 //! through the stdin loop.
 
 use std::io::{self, BufRead, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
@@ -30,7 +31,10 @@ use serde_json::{json, Value};
 
 use crate::config::{self, Config};
 use crate::herdr;
-use crate::protocol::{GotoTarget, Handoff, LineRange, OpenReview, ReviewRequest, ReviewResult, PROTOCOL_VERSION};
+use crate::protocol::{
+    GotoTarget, Handoff, LineRange, OpenReview, ReviewRequest, ReviewResult, Verdict,
+    VerdictNotify, PROTOCOL_VERSION,
+};
 
 const REVIEW_CHANGES: &str = "review_changes";
 const SHOW_CHANGES: &str = "show_changes";
@@ -45,6 +49,11 @@ struct ActiveReview {
     open: OpenReview,
     working_dir: String,
     opened_at: Instant,
+    /// True while a `collect_review` call is checking or waiting for the
+    /// verdict. The mailbox thread's nudge callback reads it: an agent
+    /// already polling gets the verdict as that call's return value, so
+    /// typing a "call collect_review" prompt at it too would be noise.
+    collector_waiting: Arc<AtomicBool>,
 }
 
 pub fn run() -> Result<()> {
@@ -149,7 +158,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": SHOW_CHANGES,
-            "description": "Open a review pane beside this agent and return immediately — for a guided walkthrough where you explain the diff in chat while the human reads it at their own pace. Typical flow: call show_changes to open the pane, call goto once per point you want to highlight as you narrate it (and focus to fold a long file down to just the regions you are discussing), then call collect_review to get the verdict and annotations once you're done (or whenever you want to check). Same arguments as review_changes: baseline, note, working_dir. Unlike review_changes this never blocks and has no timeout — nothing here is waiting on the human, so there's nothing to time out; the review stays open until the reviewer finishes in the pane or you call collect_review. Only one review may be open at a time: fails if one is already open.",
+            "description": "Open a review pane beside this agent and return immediately — for a guided walkthrough where you explain the diff in chat while the human reads it at their own pace. Typical flow: call show_changes to open the pane, call goto once per point you want to highlight as you narrate it (and focus to fold a long file down to just the regions you are discussing), then call collect_review to get the verdict and annotations once you're done (or whenever you want to check). Same arguments as review_changes: baseline, note, working_dir. Unlike review_changes this never blocks and has no timeout — nothing here is waiting on the human, so there's nothing to time out; the review stays open until the reviewer finishes in the pane or you call collect_review. If the reviewer finishes while you are not polling, the server sends a short '[herdr-annotator] The reviewer finished…' prompt into your chat — when you see it, call collect_review and act on the feedback. Only one review may be open at a time: fails if one is already open.",
             "inputSchema": review_input_schema(),
         }),
         json!({
@@ -404,6 +413,14 @@ fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Val
     };
     let deadline = Instant::now() + Duration::from_secs(wait_seconds);
 
+    // While this call is checking, a verdict that lands belongs to this
+    // call's return value — flag the mailbox thread off the nudge. The flag
+    // comes back down only on the pending path; once the verdict is taken
+    // the review is gone and there is nothing left to nudge about.
+    if let Some(a) = active.as_ref() {
+        a.collector_waiting.store(true, Ordering::SeqCst);
+    }
+
     loop {
         let taken = active.as_ref().and_then(|a| a.open.try_take());
         match taken {
@@ -421,6 +438,9 @@ fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Val
             None => {}
         }
         if wait_seconds == 0 || Instant::now() >= deadline {
+            if let Some(a) = active.as_ref() {
+                a.collector_waiting.store(false, Ordering::SeqCst);
+            }
             let open_for_secs = active
                 .as_ref()
                 .map(|a| a.opened_at.elapsed().as_secs())
@@ -520,13 +540,56 @@ fn run_review(args: &Value, config: &Config) -> Result<ReviewResult> {
 
 fn run_show(args: &Value, config: &Config) -> Result<ActiveReview> {
     let prepared = prepare_handoff(args, config)?;
-    let open = prepared.handoff.open(&prepared.request)?;
+    let collector_waiting = Arc::new(AtomicBool::new(false));
+    let notify: Option<VerdictNotify> = if config.notify_on_verdict {
+        let waiting = Arc::clone(&collector_waiting);
+        Some(Box::new(move |result: &ReviewResult| {
+            if waiting.load(Ordering::SeqCst) {
+                return;
+            }
+            let message = nudge_message(result);
+            if let Err(err) = herdr::nudge_agent_pane(&message) {
+                eprintln!("herdr-annotator mcp: could not deliver the verdict nudge ({err:#})");
+            }
+        }))
+    } else {
+        None
+    };
+    let open = prepared.handoff.open_with_notify(&prepared.request, notify)?;
     eprintln!("herdr-annotator mcp: review pane open, returning control to the agent");
     Ok(ActiveReview {
         open,
         working_dir: prepared.working_dir,
         opened_at: Instant::now(),
+        collector_waiting,
     })
+}
+
+/// The line typed into the agent's pane when a verdict lands unasked. Carries
+/// only the verdict name and the annotation count — the feedback itself stays
+/// behind `collect_review`, so the verdict is consumed exactly once through
+/// the normal tool path.
+fn nudge_message(result: &ReviewResult) -> String {
+    match result.verdict {
+        Verdict::Cancelled => "[herdr-annotator] The review pane closed without a verdict. \
+             Call collect_review to confirm, then continue."
+            .to_string(),
+        verdict => {
+            let verdict = serde_json::to_value(verdict)
+                .ok()
+                .and_then(|v| v.as_str().map(str::to_string))
+                .unwrap_or_else(|| format!("{verdict:?}"));
+            let annotations = match result.annotations.len() {
+                0 => "no annotations".to_string(),
+                1 => "1 annotation".to_string(),
+                n => format!("{n} annotations"),
+            };
+            format!(
+                "[herdr-annotator] The reviewer finished: {verdict} with {annotations}. \
+                 Call collect_review to fetch the feedback and act on it."
+            )
+        }
+    }
 }
 
 #[cfg(test)]
@@ -582,7 +645,12 @@ mod tests {
         let _ = std::fs::remove_file(&sock);
 
         (
-            ActiveReview { open, working_dir: "/tmp/repo".into(), opened_at: Instant::now() },
+            ActiveReview {
+                open,
+                working_dir: "/tmp/repo".into(),
+                opened_at: Instant::now(),
+                collector_waiting: Arc::new(AtomicBool::new(false)),
+            },
             pane,
             release_tx,
         )
@@ -613,6 +681,62 @@ mod tests {
         assert!(active.is_none(), "collecting a verdict must clear the active review");
 
         pane.join().unwrap();
+    }
+
+    #[test]
+    fn a_pending_collect_lowers_the_collector_flag_so_a_later_verdict_still_nudges() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let flag = Arc::clone(&active_review.collector_waiting);
+        let mut active = Some(active_review);
+
+        let pending = handle_collect_review(&json!({}), &mut active);
+        assert_eq!(pending["isError"], false);
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "the flag must come back down on the pending path — a verdict landing after this call returned belongs to the nudge"
+        );
+
+        release_tx.send(()).unwrap();
+        let _ = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        pane.join().unwrap();
+    }
+
+    #[test]
+    fn nudge_messages_carry_the_verdict_and_count_but_never_the_feedback() {
+        let annotation = Annotation {
+            file: "src/lib.rs".into(),
+            lines: LineRange { start: 1, end: 2 },
+            side: Side::New,
+            tag: Some("fix".into()),
+            comment: "secret feedback".into(),
+        };
+        let request_changes = ReviewResult {
+            version: PROTOCOL_VERSION,
+            verdict: Verdict::RequestChanges,
+            summary: Some("secret summary".into()),
+            annotations: vec![annotation.clone(), annotation.clone(), annotation],
+        };
+        let msg = nudge_message(&request_changes);
+        assert!(msg.contains("request_changes with 3 annotations"), "unexpected message: {msg}");
+        assert!(msg.contains("collect_review"), "the nudge must point at the tool: {msg}");
+        assert!(
+            !msg.contains("secret"),
+            "annotation bodies and summaries must stay behind collect_review: {msg}"
+        );
+
+        let approve = ReviewResult {
+            version: PROTOCOL_VERSION,
+            verdict: Verdict::Approve,
+            summary: None,
+            annotations: Vec::new(),
+        };
+        let msg = nudge_message(&approve);
+        assert!(msg.contains("approve with no annotations"), "unexpected message: {msg}");
+
+        let cancelled = ReviewResult::cancelled("review pane closed without a verdict");
+        let msg = nudge_message(&cancelled);
+        assert!(msg.contains("without a verdict"), "unexpected message: {msg}");
+        assert!(msg.contains("collect_review"), "the nudge must point at the tool: {msg}");
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -438,8 +438,27 @@ fn handle_collect_review(args: &Value, active: &mut Option<ActiveReview>) -> Val
             None => {}
         }
         if wait_seconds == 0 || Instant::now() >= deadline {
+            #[cfg(test)]
+            tests::pending_path_test_hook();
             if let Some(a) = active.as_ref() {
                 a.collector_waiting.store(false, Ordering::SeqCst);
+            }
+            // Look one last time *after* lowering the flag. A verdict
+            // deposited since the loop's check was flagged off the nudge by
+            // the raised flag; if it isn't returned here it is stranded with
+            // no continuation signal at all. Rechecking after the store
+            // guarantees every verdict gets exactly one of: returned by this
+            // call, or nudged.
+            match active.as_ref().and_then(|a| a.open.try_take()) {
+                Some(Ok(result)) => {
+                    *active = None;
+                    return review_result_response(&result);
+                }
+                Some(Err(err)) => {
+                    *active = None;
+                    return tool_error(format!("{err:#}"));
+                }
+                None => {}
             }
             let open_for_secs = active
                 .as_ref()
@@ -598,6 +617,22 @@ mod tests {
     use crate::protocol::{Annotation, LineRange, PaneConnection, Side, Verdict};
     use std::os::unix::net::UnixListener;
 
+    thread_local! {
+        /// Runs at the top of `handle_collect_review`'s pending path, inside
+        /// the race window between the loop's last mailbox check and the
+        /// flag store — lets a test deposit a verdict exactly there.
+        static PENDING_PATH_HOOK: std::cell::RefCell<Option<Box<dyn FnMut()>>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    pub(super) fn pending_path_test_hook() {
+        PENDING_PATH_HOOK.with(|h| {
+            if let Some(f) = h.borrow_mut().as_mut() {
+                f();
+            }
+        });
+    }
+
     /// Stand up a fake pane on a unix socket (same pattern as protocol.rs's
     /// tests) and hand back an `ActiveReview` wired to it, plus the pane's
     /// thread handle and a sender the test uses to release the verdict on
@@ -698,6 +733,37 @@ mod tests {
 
         release_tx.send(()).unwrap();
         let _ = handle_collect_review(&json!({ "wait_seconds": 5 }), &mut active);
+        pane.join().unwrap();
+    }
+
+    #[test]
+    fn a_verdict_landing_inside_the_pending_window_is_returned_not_stranded() {
+        let (active_review, pane, release_tx) = open_fake_review();
+        let mut active = Some(active_review);
+
+        // Deposit the verdict inside the race window: after the loop's last
+        // mailbox check, while collector_waiting is still up (so a wired
+        // nudge would be suppressed). The call must return the verdict —
+        // returning "pending" here strands it with no continuation signal.
+        PENDING_PATH_HOOK.with(|h| {
+            *h.borrow_mut() = Some(Box::new(move || {
+                let _ = release_tx.send(());
+                // Give the pane and mailbox threads time to deposit.
+                std::thread::sleep(Duration::from_millis(500));
+            }));
+        });
+        let out = handle_collect_review(&json!({}), &mut active);
+        PENDING_PATH_HOOK.with(|h| *h.borrow_mut() = None);
+
+        assert_eq!(out["isError"], false);
+        let result: ReviewResult =
+            serde_json::from_str(out["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            result.verdict,
+            Verdict::Approve,
+            "a verdict deposited during the pending window must be returned, not stranded behind a suppressed nudge"
+        );
+        assert!(active.is_none(), "collecting a verdict must clear the active review");
         pane.join().unwrap();
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -83,7 +83,7 @@ pub fn run() -> Result<()> {
             ("initialize", Some(id)) => Some(result_frame(id, initialize_result(&params))),
             ("ping", Some(id)) => Some(result_frame(id, json!({}))),
             ("tools/list", Some(id)) => {
-                Some(result_frame(id, json!({ "tools": tool_descriptors() })))
+                Some(result_frame(id, json!({ "tools": tool_descriptors(&config) })))
             }
             ("tools/call", Some(id)) => {
                 Some(result_frame(id, handle_tool_call(&params, &config, &mut active)))
@@ -149,7 +149,15 @@ fn review_input_schema() -> Value {
     })
 }
 
-fn tool_descriptors() -> Vec<Value> {
+/// Takes the config because show_changes' description promises the verdict
+/// nudge — a promise that must disappear when `notify_on_verdict = false`,
+/// or the agent waits for a prompt that never comes.
+fn tool_descriptors(config: &Config) -> Vec<Value> {
+    let nudge_promise = if config.notify_on_verdict {
+        " If the reviewer finishes while you are not polling, the server sends a short '[herdr-annotator] The reviewer finished…' prompt into your chat — when you see it, call collect_review and act on the feedback."
+    } else {
+        ""
+    };
     vec![
         json!({
             "name": REVIEW_CHANGES,
@@ -158,7 +166,7 @@ fn tool_descriptors() -> Vec<Value> {
         }),
         json!({
             "name": SHOW_CHANGES,
-            "description": "Open a review pane beside this agent and return immediately — for a guided walkthrough where you explain the diff in chat while the human reads it at their own pace. Typical flow: call show_changes to open the pane, call goto once per point you want to highlight as you narrate it (and focus to fold a long file down to just the regions you are discussing), then call collect_review to get the verdict and annotations once you're done (or whenever you want to check). Same arguments as review_changes: baseline, note, working_dir. Unlike review_changes this never blocks and has no timeout — nothing here is waiting on the human, so there's nothing to time out; the review stays open until the reviewer finishes in the pane or you call collect_review. If the reviewer finishes while you are not polling, the server sends a short '[herdr-annotator] The reviewer finished…' prompt into your chat — when you see it, call collect_review and act on the feedback. Only one review may be open at a time: fails if one is already open.",
+            "description": format!("Open a review pane beside this agent and return immediately — for a guided walkthrough where you explain the diff in chat while the human reads it at their own pace. Typical flow: call show_changes to open the pane, call goto once per point you want to highlight as you narrate it (and focus to fold a long file down to just the regions you are discussing), then call collect_review to get the verdict and annotations once you're done (or whenever you want to check). Same arguments as review_changes: baseline, note, working_dir. Unlike review_changes this never blocks and has no timeout — nothing here is waiting on the human, so there's nothing to time out; the review stays open until the reviewer finishes in the pane or you call collect_review.{nudge_promise} Only one review may be open at a time: fails if one is already open."),
             "inputSchema": review_input_schema(),
         }),
         json!({
@@ -590,8 +598,11 @@ fn run_show(args: &Value, config: &Config) -> Result<ActiveReview> {
 /// the normal tool path.
 fn nudge_message(result: &ReviewResult) -> String {
     match result.verdict {
+        // Deliberately neutral about what happens next: a cancellation can be
+        // a deliberate human stop, so the nudge only says the review is over
+        // and leaves the reaction to the agent's own operating instructions.
         Verdict::Cancelled => "[herdr-annotator] The review pane closed without a verdict. \
-             Call collect_review to confirm, then continue."
+             Call collect_review to confirm the cancellation."
             .to_string(),
         verdict => {
             let verdict = serde_json::to_value(verdict)
@@ -765,6 +776,31 @@ mod tests {
         );
         assert!(active.is_none(), "collecting a verdict must clear the active review");
         pane.join().unwrap();
+    }
+
+    #[test]
+    fn show_changes_promises_the_nudge_only_when_the_config_delivers_it() {
+        let on = Config::default();
+        let with_nudge = tool_descriptors(&on);
+        let desc = |tools: &[Value]| {
+            tools
+                .iter()
+                .find(|t| t["name"] == SHOW_CHANGES)
+                .and_then(|t| t["description"].as_str())
+                .unwrap()
+                .to_string()
+        };
+        assert!(
+            desc(&with_nudge).contains("[herdr-annotator]"),
+            "with notify_on_verdict on, the description must tell the agent about the nudge"
+        );
+
+        let off = Config { notify_on_verdict: false, ..Config::default() };
+        let without_nudge = tool_descriptors(&off);
+        assert!(
+            !desc(&without_nudge).contains("[herdr-annotator]"),
+            "with notify_on_verdict off, the description must not promise a prompt that never comes"
+        );
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -165,6 +165,11 @@ pub fn read_json_line<T: DeserializeOwned, R: BufRead>(reader: &mut R) -> Result
     Ok(Some(value))
 }
 
+/// Callback invoked by the mailbox thread when a verdict lands (see
+/// `Handoff::open_with_notify`). Runs on that thread, so it must not block
+/// for long.
+pub type VerdictNotify = Box<dyn FnOnce(&ReviewResult) + Send + 'static>;
+
 /// Server side: bind, then wait up to `accept_timeout` for the pane to connect.
 /// Accepting runs on a throwaway thread so the timeout can't wedge the caller.
 pub struct Handoff {
@@ -198,7 +203,20 @@ impl Handoff {
     /// vocabulary and surfaced as an `Err` instead — callers that treat
     /// `Cancelled` as "nothing to worry about" must not see a protocol bug
     /// dressed up as one.
-    pub fn open(mut self, request: &ReviewRequest) -> Result<OpenReview> {
+    pub fn open(self, request: &ReviewRequest) -> Result<OpenReview> {
+        self.open_with_notify(request, None)
+    }
+
+    /// Like `open`, but with an optional callback the mailbox thread invokes
+    /// once a verdict lands. The verdict is deposited in the mailbox *before*
+    /// the callback runs, so a caller reacting to the notification can
+    /// immediately `try_take` it. Broken channels (`Err` outcomes) do not
+    /// notify — they are protocol failures, not reviewer decisions.
+    pub fn open_with_notify(
+        mut self,
+        request: &ReviewRequest,
+        notify: Option<VerdictNotify>,
+    ) -> Result<OpenReview> {
         write_json_line(&mut self.stream, &ServerMsg::Request(request.clone()))?;
         let writer = self.stream.try_clone().context("splitting review socket")?;
         let result = std::sync::Arc::new(std::sync::Mutex::new(None));
@@ -213,8 +231,15 @@ impl Handoff {
                     Err(err) => Err(format!("{err:#}")),
                 }
             };
+            let notification = match (&outcome, notify) {
+                (Ok(result), Some(callback)) => Some((callback, result.clone())),
+                _ => None,
+            };
             if let Ok(mut slot) = mailbox.lock() {
                 *slot = Some(outcome);
+            }
+            if let Some((callback, result)) = notification {
+                callback(&result);
             }
         });
         Ok(OpenReview { writer, result })
@@ -445,6 +470,134 @@ mod tests {
         let result = open.wait(Some(Duration::from_secs(5))).unwrap();
         pane.join().unwrap();
         assert_eq!(result.verdict, Verdict::Approve);
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn notify_fires_with_the_verdict_already_in_the_mailbox() {
+        let dir = std::env::temp_dir().join(format!("annot-test-notify-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            let (mut channel, _goto_rx) = conn.into_channel();
+            channel
+                .send_result(&ReviewResult {
+                    version: PROTOCOL_VERSION,
+                    verdict: Verdict::Approve,
+                    summary: None,
+                    annotations: Vec::new(),
+                })
+                .unwrap();
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let (notified_tx, notified_rx) = mpsc::channel::<Verdict>();
+        let open = handoff
+            .open_with_notify(
+                &ReviewRequest {
+                    version: PROTOCOL_VERSION,
+                    working_dir: "/tmp/repo".into(),
+                    baseline: None,
+                    note: None,
+                },
+                Some(Box::new(move |result| {
+                    notified_tx.send(result.verdict).unwrap();
+                })),
+            )
+            .unwrap();
+
+        let verdict = notified_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(verdict, Verdict::Approve);
+        // Deposit-before-notify: a caller reacting to the notification must
+        // find the verdict already collectable.
+        let taken = open.try_take().expect("verdict must be in the mailbox when notify fires");
+        assert_eq!(taken.unwrap().verdict, Verdict::Approve);
+        pane.join().unwrap();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn notify_fires_for_a_pane_that_closes_without_a_verdict() {
+        let dir = std::env::temp_dir().join(format!("annot-test-notify-eof-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            // Drop without answering: EOF, a genuine cancelled verdict.
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let (notified_tx, notified_rx) = mpsc::channel::<Verdict>();
+        let _open = handoff
+            .open_with_notify(
+                &ReviewRequest {
+                    version: PROTOCOL_VERSION,
+                    working_dir: "/tmp/repo".into(),
+                    baseline: None,
+                    note: None,
+                },
+                Some(Box::new(move |result| {
+                    notified_tx.send(result.verdict).unwrap();
+                })),
+            )
+            .unwrap();
+
+        let verdict = notified_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(verdict, Verdict::Cancelled);
+        pane.join().unwrap();
+        let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn a_broken_channel_does_not_notify() {
+        let dir = std::env::temp_dir().join(format!("annot-test-notify-err-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let sock = dir.join("t.sock");
+        let _ = std::fs::remove_file(&sock);
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let sock_client = sock.clone();
+        let pane = std::thread::spawn(move || {
+            let mut conn = PaneConnection::connect(&sock_client).unwrap();
+            let _ = conn.receive_request().unwrap();
+            conn.stream.write_all(b"not json\n").unwrap();
+        });
+
+        let handoff = Handoff::accept(listener, Duration::from_secs(5)).unwrap();
+        let notified = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let notified_in_callback = std::sync::Arc::clone(&notified);
+        let open = handoff
+            .open_with_notify(
+                &ReviewRequest {
+                    version: PROTOCOL_VERSION,
+                    working_dir: "/tmp/repo".into(),
+                    baseline: None,
+                    note: None,
+                },
+                Some(Box::new(move |_| {
+                    notified_in_callback.store(true, std::sync::atomic::Ordering::SeqCst);
+                })),
+            )
+            .unwrap();
+
+        let outcome = open.wait(Some(Duration::from_secs(5)));
+        assert!(outcome.is_err(), "a malformed reply is a broken channel, not a verdict");
+        assert!(
+            !notified.load(std::sync::atomic::Ordering::SeqCst),
+            "protocol failures must not type a nudge at the agent"
+        );
+        pane.join().unwrap();
         let _ = std::fs::remove_file(&sock);
     }
 


### PR DESCRIPTION
## Problem

`show_changes` had a dead end in its loop: the agent opens the pane and goes idle; the reviewer annotates and finishes; nothing tells the agent feedback is waiting. The human had to type "I'm done" — manual dispatch in a flow that's otherwise automated. Closes the gap without making `show_changes` blocking.

## How

MCP has no server-initiated wakeup — an idle agent only runs when something lands in its chat. But this server is a herdr citizen: it inherits `HERDR_PANE_ID`, so it knows exactly which pane the agent lives in, and its mailbox thread learns the verdict the moment the pane delivers it. When a verdict lands and no `collect_review` call is waiting on it, the server types one line into the agent's pane and submits it:

> [herdr-annotator] The reviewer finished: request_changes with 3 annotations. Call collect_review to fetch the feedback and act on it.

The agent wakes, calls `collect_review`, and acts — a full round trip with no human dispatching. Agent-agnostic: works for any agent CLI in a herdr pane.

## Design points

- **The nudge carries only the verdict name and annotation count.** The feedback itself stays behind `collect_review`, so the verdict is consumed exactly once through the normal tool path.
- **No double delivery.** A `collector_waiting` flag is raised while a `collect_review` call is checking or polling; the mailbox thread's callback sees it and stays quiet — the verdict arrives as that call's return value. The flag comes back down on the pending path, so a verdict landing later still nudges.
- **Deposit before notify.** The callback runs only after the verdict is in the mailbox, so an agent reacting instantly always finds it collectable.
- **Broken channels never nudge.** Protocol failures surface as tool errors, not typed prompts. A pane closed without a verdict does nudge ("closed without a verdict") — the agent should learn the review is over.
- **`review_changes` is untouched** — blocking, the verdict is its return value.
- **Config:** `notify_on_verdict` (default `true`) turns it off.
- The `show_changes` tool description now tells the agent what the injected prompt looks like, so it recognizes it instead of being puzzled.

## Verification

- 150 tests (8 new): notify ordering + EOF-cancelled + broken-channel suppression at the protocol layer, CLI argv contract + missing-pane-id handling for the nudge, collector-flag lifecycle, message formatting (verdict + count present, annotation bodies absent), config parsing.
- Live smoke in a throwaway herdr session: `show_changes` → approve in the real review pane → nudge typed and submitted into the agent pane (the shell even executed it, proving Enter went through) → `collect_review` still returned the verdict.
- `pane send-text` / `send-keys <id> enter` argv shapes match what the demo rig already uses against herdr 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)