### PR TITLE
README: banner and badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# herdr-file-annotator
+<div align="center">
+  <p>
+    <img src="docs/img/banner.svg" alt="herdr-file-annotator: annotate the code, not the prompt" width="800">
+  </p>
+  <p>
+    <a href="https://github.com/JonasBaeumer/herdr-file-annotator/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/JonasBaeumer/herdr-file-annotator/ci.yml?branch=main&style=for-the-badge&logo=githubactions&logoColor=white&label=CI&labelColor=000000" alt="CI status"></a>
+    <a href="https://github.com/JonasBaeumer/herdr-file-annotator/releases"><img src="https://img.shields.io/github/v/release/JonasBaeumer/herdr-file-annotator?style=for-the-badge&logo=github&logoColor=white&color=bd93f9&labelColor=000000" alt="Latest release"></a>
+    <a href="https://herdr.dev"><img src="https://img.shields.io/badge/herdr-%E2%89%A5%200.8.0-bd93f9?style=for-the-badge&labelColor=000000" alt="Requires herdr 0.8.0 or newer"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-bd93f9?style=for-the-badge&labelColor=000000" alt="MIT license"></a>
+  </p>
+</div>
 
 **Maximize agentic development but don't lose touch with the actual codebase.**
 

--- a/docs/img/banner.svg
+++ b/docs/img/banner.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="220" viewBox="0 0 800 220" role="img" aria-label="herdr-file-annotator: annotate the code, not the prompt">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#20222e"/>
+      <stop offset="1" stop-color="#15161d"/>
+    </linearGradient>
+  </defs>
+
+  <!-- card -->
+  <rect width="800" height="220" rx="14" fill="url(#bg)"/>
+  <rect x="0.5" y="0.5" width="799" height="219" rx="13.5" fill="none" stroke="#343648" stroke-width="1"/>
+
+  <!-- wordmark + tagline -->
+  <g font-family="-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="48" y="86" font-size="30" font-weight="700" fill="#f8f8f2">herdr-file-annotator</text>
+    <text x="48" y="124" font-size="19" font-weight="600" fill="#bd93f9">Annotate the code, not the prompt.</text>
+    <text x="48" y="152" font-size="13.5" fill="#8b91a7">Agent-summoned code review panes,</text>
+    <text x="48" y="172" font-size="13.5" fill="#8b91a7">right in your herdr workspace.</text>
+  </g>
+
+  <!-- mini review pane -->
+  <g>
+    <rect x="478" y="30" width="284" height="160" rx="10" fill="#282a36"/>
+    <rect x="478.5" y="30.5" width="283" height="159" rx="9.5" fill="none" stroke="#3d4054" stroke-width="1"/>
+    <!-- pane header -->
+    <circle cx="496" cy="46" r="4" fill="#ff5555"/>
+    <circle cx="510" cy="46" r="4" fill="#f1fa8c"/>
+    <circle cx="524" cy="46" r="4" fill="#50fa7b"/>
+    <text x="744" y="50" text-anchor="end" font-family="ui-monospace, Menlo, Consolas, monospace" font-size="10.5" fill="#6272a4">src/retry.py</text>
+    <line x1="479" y1="58" x2="761" y2="58" stroke="#3d4054" stroke-width="1"/>
+
+    <!-- diff lines -->
+    <g font-family="ui-monospace, Menlo, Consolas, monospace" font-size="12">
+      <text x="508" y="80" fill="#6272a4">for i in range(attempts):</text>
+      <text x="494" y="99" fill="#ff5555">-</text>
+      <text x="522" y="99" fill="#ff5555">time.sleep(1)</text>
+      <rect x="486" y="106" width="268" height="19" rx="3" fill="#1d3323"/>
+      <text x="494" y="120" fill="#50fa7b">+</text>
+      <text x="522" y="120" fill="#50fa7b">time.sleep(2 ** i)</text>
+    </g>
+
+    <!-- inline annotation -->
+    <rect x="486" y="134" width="268" height="42" rx="6" fill="#211d2e"/>
+    <rect x="486" y="134" width="3" height="42" rx="1.5" fill="#bd93f9"/>
+    <g font-family="ui-monospace, Menlo, Consolas, monospace">
+      <rect x="498" y="141" width="62" height="15" rx="7.5" fill="#3a2f55"/>
+      <text x="529" y="152" text-anchor="middle" font-size="10" fill="#d3bfff">question</text>
+      <text x="498" y="169" font-size="11.5" fill="#cfd3e0">cap this with MAX_BACKOFF?</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## What

Gives the README the same head treatment as [herdr-auto-title](https://github.com/kryptamine/herdr-auto-title): a centered banner over a `for-the-badge` shields row, then the existing pitch continues unchanged.

- **Banner** (`docs/img/banner.svg`): name, the "Annotate the code, not the prompt." tagline, and — instead of abstract art — a mini review pane with a real diff and an inline `question` annotation, in the same dracula palette as the demo GIF. Hand-written SVG: crisp at any width, ~3 KB, no binary asset to regenerate.
- **Badges**: CI status (live, `ci.yml` on main), latest release, `herdr ≥ 0.8.0` requirement (where auto-title shows its Go version), MIT license. Black labels, the banner's purple as accent.

The `# herdr-file-annotator` h1 is replaced by the banner, matching the reference style; everything from the bold opening line down is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)