### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "herdr-annotator"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "herdr-annotator"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 description = "Herdr plugin: an agent-summoned, blocking diff-review pane with line annotations."

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -7,7 +7,7 @@
 
 id = "jonasbaeumer.file-annotator"
 name = "File Annotator"
-version = "0.8.1"
+version = "0.9.0"
 min_herdr_version = "0.8.0"
 description = "Agent-summoned, blocking diff review: the agent calls an MCP tool, a review pane opens beside it, and the agent waits for your verdict and line annotations."
 platforms = ["macos", "linux"]


### PR DESCRIPTION
Release prep for v0.9.0: the verdict nudge (#28) and the README banner/badges (#29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)